### PR TITLE
propagate mandatory tag when converting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+## [0.1.3]
+
+### Changed
+
+- Hermes convert deliverables now sends a mandatory field as response
+
 ## [0.1.2]
-### Added
 
 ### Fixed
 

--- a/cg_hermes/deliverables.py
+++ b/cg_hermes/deliverables.py
@@ -90,7 +90,7 @@ class Deliverables:
         cg_tags.extend(
             [tool for tool in conversion_info.used_by if tool not in ["cg", "audit", "store"]]
         )
-        return CGTag(path=path, tags=cg_tags)
+        return CGTag(path=path, tags=cg_tags, mandatory=conversion_info.is_mandatory)
 
     def convert_to_cg_deliverables(self) -> CGDeliverables:
         """Convert pipeline specific information from deliverables file to CG formatted information"""
@@ -179,11 +179,7 @@ class Deliverables:
             if file_obj.tag:
                 identifier.append(file_obj.tag)
             files.append(
-                TagBase(
-                    tags=frozenset(identifier),
-                    subject_id=file_obj.id,
-                    path=file_obj.path,
-                )
+                TagBase(tags=frozenset(identifier), subject_id=file_obj.id, path=file_obj.path,)
             )
         return files
 

--- a/cg_hermes/models/tags.py
+++ b/cg_hermes/models/tags.py
@@ -26,3 +26,4 @@ class TagMap(BaseModel):
 class CGTag(BaseModel):
     path: str
     tags: List[str]
+    mandatory: bool


### PR DESCRIPTION
### This PR adds | fixes:
- Propagate mandatory tag as a response to `hermes convert deliverables
`


**How to prepare for test**:
- [x] `ssh` to hasta
- [x] Install on stage:
`source activate S_hermes && pip install git+https://github.com/Clinical-Genomics/hermes.git@feat/propagate-mandatory`


### How to test:
- Store microsalt deliverables

### Expected outcome:
- [x] Deliverables stored

### Review:
- [x] Code approved by MM
- [x] Tests executed by MR
- [x] "Merge and deploy" approved by MM

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner

