### PR TITLE
add balsamic delivery tag

### DIFF
--- a/.idea/hermes.iml
+++ b/.idea/hermes.iml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.9 (hermes)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
   </component>
 </module>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+## [0.2]
+
+### Added
+
+- Add a delivery-report tag to balsamic
 
 ## [0.1.4]
 

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -37,7 +37,7 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
-    frozenset({"delivery_report"}): {
+    frozenset({"balsamic_delivery"}): {
         "tags": ["delivery-report"],
         "is_mandatory": False,
         "used_by": ["scout"],

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -37,7 +37,7 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
-    frozenset({"balsamic_delivery"}): {
+    frozenset({"delivery_report"}): {
         "tags": ["delivery-report"],
         "is_mandatory": False,
         "used_by": ["scout"],

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -37,6 +37,11 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
+    frozenset({"delivery-report"}): {
+        "tags": ["delivery_report"],
+        "is_mandatory": True,
+        "used_by": ["scout"],
+    },
     frozenset({"multiqc-html", "html"}): {
         "tags": ["multiqc-html"],
         "is_mandatory": True,

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -37,9 +37,9 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
-    frozenset({"delivery-report"}): {
-        "tags": ["delivery_report"],
-        "is_mandatory": True,
+    frozenset({"delivery_report"}): {
+        "tags": ["delivery-report"],
+        "is_mandatory": False,
         "used_by": ["scout"],
     },
     frozenset({"multiqc-html", "html"}): {

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -64,6 +64,7 @@ REPORTING_COMMON = {
     "sambamba-depth": {"description": "Coverage information from sambamba"},
     "vcf-report": {"description": "Results and QC from variant calling"},
     "qc-report": {"description": "Results and QC"},
+    "delivery-report": {"description": "Delivery report with result for upload to Scout"},
 }
 
 VALIDATIONS_COMMON = {


### PR DESCRIPTION
This PR adds a `delivery-report` tag to balsamic

- Adds delivery report to Balsamic. Fix #6 


