### PR TITLE
remove files which arent created yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [0.5.0]
+### Changed
+- Pangolin output from mutant is optional
+
+
 ## [0.4.0]
 ### Added
 - Support same pipeline format as cg

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -21,12 +21,12 @@ MUTANT_COMMON_TAGS = {
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-type", "typing"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["typing-report", "pangolin", "visualization"],
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-json", "result_aggregation"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["typing-report", "visualization"],
         "used_by": ["deliver"],
     },


### PR DESCRIPTION
### This PR adds | fixes:
- Makes mandatory files optional. The files in question are a placeholder and arent produced yet by mutant
### Review:
- [x] Code approved by @sylvinite
- [x] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner
