### PR TITLE
Mutant files optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [0.6.0]
+### Changed
+- Mutant output files made optional. 
+### Added  
+- New optional/placeholder tags for pangolin delivery reports.
+- New optional/placeholder tags for multiqc report
+
 ## [0.5.0]
 ### Changed
 - Pangolin output from mutant is optional

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -87,7 +87,7 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"pangolin-summary"}): {
         "is_mandatory": False,
-        "tags": ["pangolin", "summary", "csv", "report"],
+        "tags": ["pangolin", "typing-summary", "csv", "report"],
         "used_by": ["deliver"],
     },
 }

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -77,17 +77,17 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": False,
-        "tags": ["multiqc"],
+        "tags": ["multiqc-json"],
         "used_by": ["vogue"],
     },
     frozenset({"pangolin-typing"}): {
         "is_mandatory": False,
-        "tags": ["pangolin-typing", "vcf", "report"],
+        "tags": ["pangolin-typing", "csv", "report"],
         "used_by": ["deliver"],
     },
     frozenset({"pangolin-summary"}): {
         "is_mandatory": False,
-        "tags": ["pangolin-summary", "vcf", "report"],
+        "tags": ["pangolin-summary", "csv", "report"],
         "used_by": ["deliver"],
     },
 }

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -82,12 +82,12 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"pangolin-typing"}): {
         "is_mandatory": False,
-        "tags": ["pangolin", "typing-report", "csv", "report"],
+        "tags": ["pangolin", "typing-report", "csv"],
         "used_by": ["deliver"],
     },
     frozenset({"pangolin-summary"}): {
         "is_mandatory": False,
-        "tags": ["pangolin", "typing-summary", "csv", "report"],
+        "tags": ["pangolin", "typing-summary", "csv"],
         "used_by": ["deliver"],
     },
 }

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -11,12 +11,12 @@ MUTANT_COMMON_TAGS = {
         "used_by": ["deliver"],
     },
     frozenset({"variants", "variant-calling"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["tsv", "vcf-report"],
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-qc", "result_aggregation"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["qc-report", "csv", "visualization"],
         "used_by": ["deliver"],
     },
@@ -31,22 +31,22 @@ MUTANT_COMMON_TAGS = {
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-sum", "report"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["summary", "csv", "visualization"],
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-var", "report"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["variants", "csv", "visualization"],
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-info", "report"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["komplettering", "fohm", "visualization"],
         "used_by": ["deliver"],
     },
     frozenset({"runtime-settings", "runinfo"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["mutant-config"],
         "used_by": ["storage", "audit"],
     },
@@ -61,12 +61,12 @@ MUTANT_COMMON_TAGS = {
         "used_by": ["storage"],
     },
     frozenset({"consensus"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["fastq", "consensus"],
         "used_by": ["deliver", "storage"],
     },
     frozenset({"runinfo", "logfile"}): {
-        "is_mandatory": True,
+        "is_mandatory": False,
         "tags": ["mutant-log"],
         "used_by": ["audit"],
     },

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -82,12 +82,12 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"pangolin-typing"}): {
         "is_mandatory": False,
-        "tags": ["pangolin-typing", "csv", "report"],
+        "tags": ["pangolin", "typing-report", "csv", "report"],
         "used_by": ["deliver"],
     },
     frozenset({"pangolin-summary"}): {
         "is_mandatory": False,
-        "tags": ["pangolin-summary", "csv", "report"],
+        "tags": ["pangolin", "summary", "csv", "report"],
         "used_by": ["deliver"],
     },
 }

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -22,7 +22,7 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"SARS-CoV-2-type", "typing"}): {
         "is_mandatory": False,
-        "tags": ["typing-report", "pangolin", "visualization"],
+        "tags": ["typing-report", "visualization"],
         "used_by": ["deliver"],
     },
     frozenset({"SARS-CoV-2-json", "result_aggregation"}): {
@@ -74,5 +74,20 @@ MUTANT_COMMON_TAGS = {
         "is_mandatory": False,
         "tags": ["bam"],
         "used_by": ["storage"],
+    },
+    frozenset({"multiqc-json"}): {
+        "is_mandatory": False,
+        "tags": ["multiqc"],
+        "used_by": ["vogue"],
+    },
+    frozenset({"pangolin-typing"}): {
+        "is_mandatory": False,
+        "tags": ["pangolin-typing", "vcf", "report"],
+        "used_by": ["deliver"],
+    },
+    frozenset({"pangolin-summary"}): {
+        "is_mandatory": False,
+        "tags": ["pangolin-summary", "vcf", "report"],
+        "used_by": ["deliver"],
     },
 }

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -147,8 +147,6 @@ MUTANT_SPECIFIC = {
     "fohm": {"description": "Relevant for FoHM"},
     "komplettering": {"description": "Filetype specific for national uploading of microbial data"},
     "consensus": {"description": "Consensus sequence"},
-    "pangolin-typing": {"description": "Pangolin typing report"},
-    "pangolin-summary": {"description": "Summary report"},
     "multiqc-json": {"description": "Multiqc putput for uload to vogue"},
 }
 

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -143,11 +143,12 @@ MICROSALT_SPECIFIC = {
 MUTANT_SPECIFIC = {
     "mutant-config": {"description": "Config settings for mutant analysis"},
     "mutant-log": {"description": "SLURM log for mutant analysis"},
+    "pangolin": {"description": "Pangolin specific output"},
     "typing-report": {"description": "Results from typing"},
     "fohm": {"description": "Relevant for FoHM"},
     "komplettering": {"description": "Filetype specific for national uploading of microbial data"},
     "consensus": {"description": "Consensus sequence"},
-    "multiqc-json": {"description": "Multiqc putput for uload to vogue"},
+    "multiqc-json": {"description": "Multiqc output for upload to vogue"},
 }
 
 AVAILABLE_USAGES = {

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -145,10 +145,10 @@ MUTANT_SPECIFIC = {
     "mutant-log": {"description": "SLURM log for mutant analysis"},
     "pangolin": {"description": "Pangolin specific output"},
     "typing-report": {"description": "Results from typing"},
+    "typing-summary": {"description": "Summary of results from typing"},
     "fohm": {"description": "Relevant for FoHM"},
     "komplettering": {"description": "Filetype specific for national uploading of microbial data"},
     "consensus": {"description": "Consensus sequence"},
-    "multiqc-json": {"description": "Multiqc output for upload to vogue"},
 }
 
 AVAILABLE_USAGES = {

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -145,9 +145,11 @@ MUTANT_SPECIFIC = {
     "mutant-log": {"description": "SLURM log for mutant analysis"},
     "typing-report": {"description": "Results from typing"},
     "fohm": {"description": "Relevant for FoHM"},
-    "pangolin": {"description": "Pangolin classified output"},
     "komplettering": {"description": "Filetype specific for national uploading of microbial data"},
     "consensus": {"description": "Consensus sequence"},
+    "pangolin-typing": {"description": "Pangolin typing report"},
+    "pangolin-summary": {"description": "Summary report"},
+    "multiqc-json": {"description": "Multiqc putput for uload to vogue"},
 }
 
 AVAILABLE_USAGES = {

--- a/tests/fixtures/mutant/deliverables.yaml
+++ b/tests/fixtures/mutant/deliverables.yaml
@@ -89,3 +89,21 @@ files:
   path_index: '~'
   step: variant-calling
   tag: variants
+- format: csv
+  id: merrymink
+  path: merrymink-pangolin-typing.csv
+  path_index: '~'
+  step: report
+  tag: pangolin-typing
+- format: csv
+  id: merrymink
+  path: merrymink-pangolin-summary.csv
+  path_index: '~'
+  step: report
+  tag: pangolin-summary
+- format: json
+  id: merrymink
+  path: merrymink-multiqc.json
+  path_index: '~'
+  step: multiqc
+  tag: multiqc


### PR DESCRIPTION
### This PR adds | fixes:
- Make most of mutant output optional
- Add placeholders for multiqc report and pangolin report

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
