### PR TITLE
feat: BALSAMIC multiqc metrics tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [1.5.5]
+### Added
+- Balsamic QC metrics tag for vogue and delivery
+
 ## [1.5.4]
 ### Added
 - Update BALSAMIC stored file with UMI 

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -40,6 +40,11 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": ["scout"],
     },
+    frozenset(["qc-metrics-yaml"]): {
+        "tags": ["qc-metrics", "deliverable"],
+        "is_mandatory": True,
+        "used_by": ["vogue", "deliver"],
+    },
     frozenset({"multiqc-html", "html"}): {
         "tags": ["multiqc-html"],
         "is_mandatory": True,

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -67,6 +67,7 @@ FAMILY_COMMON = {
 
 REPORTING_COMMON = {
     "csv": {"description": "Comma separated values"},
+    "deliverable": {"description": "Deliverables file"},
     "delivery-report": {"description": "Delivery report with result for upload to Scout"},
     "multiqc-html": {"description": "Multiqc report for the run in html format"},
     "multiqc-json": {"description": "Multiqc report for the run in json format"},

--- a/docs/all_tags.md
+++ b/docs/all_tags.md
@@ -52,6 +52,7 @@
 
 | Tag name       | Description                               |
 |----------------|-------------------------------------------|
+| deliverable    | CG deliverables file                      |
 | multiqc-html   | Multiqc report for the run in html format |
 | multiqc-json   | Multiqc report for the run in json format |
 | pdf            | Portable document format                  |

--- a/docs/balsamic_map.md
+++ b/docs/balsamic_map.md
@@ -6,6 +6,7 @@
 | diagram, cnv-diagram                                               | True        | cnvkit, visualization, diagram                   | deliver               |
 | gene-breaks, cnv-gene-breaks                                       | True        | cnvkit, genes                                    | storage               |
 | cnv-gene-metrics, gene-metrics                                     | True        | cnvkit, genes, metrics                           | deliver               |
+| qc-metrics-yaml                                                    | True        | qc-metrics, deliverable                          | vogue, deliver        |
 | html, multiqc-html                                                 | True        | multiqc-html                                     | scout, deliver, audit |
 | multiqc-json, json                                                 | True        | multiqc-json                                     | vogue, audit          |
 | scout-bam, bam                                                     | False       | bam                                              | scout                 |

--- a/tests/fixtures/balsamic/TN_panel.hk
+++ b/tests/fixtures/balsamic/TN_panel.hk
@@ -889,6 +889,15 @@
             "id": "TN_panel"
         },
         {
+            "path": "TN_panel/analysis/delivery_report/TN_panel_metrics_deliverables.yaml",
+            "step": "balsamic_delivery",
+            "format": "yaml",
+            "tag": [
+                "qc-metrics-yaml"
+            ],
+            "id": "TN_panel"
+        },
+        {
             "path": "TN_panel/TN_panel.json",
             "step": "case_config",
             "format": "json",

--- a/tests/fixtures/balsamic/TN_wgs.hk
+++ b/tests/fixtures/balsamic/TN_wgs.hk
@@ -639,6 +639,7 @@
             ],
             "id": "TN_WGS"
         },
+        {
             "path": "TN_WGS/analysis/delivery_report/TN_WGS_metrics_deliverables.yaml",
             "step": "balsamic_delivery",
             "format": "yaml",

--- a/tests/fixtures/balsamic/TN_wgs.hk
+++ b/tests/fixtures/balsamic/TN_wgs.hk
@@ -639,6 +639,14 @@
             ],
             "id": "TN_WGS"
         },
+            "path": "TN_WGS/analysis/delivery_report/TN_WGS_metrics_deliverables.yaml",
+            "step": "balsamic_delivery",
+            "format": "yaml",
+            "tag": [
+                "qc-metrics-yaml"
+            ],
+            "id": "TN_WGS"
+        },
         {
             "path": "TN_WGS/TN_WGS.json",
             "step": "case_config",

--- a/tests/fixtures/balsamic/T_panel.hk
+++ b/tests/fixtures/balsamic/T_panel.hk
@@ -666,6 +666,15 @@
             "id": "T_panel"
         },
         {
+            "path": "T_panel/analysis/delivery_report/T_panel_metrics_deliverables.yaml",
+            "step": "balsamic_delivery",
+            "format": "yaml",
+            "tag": [
+                "qc-metrics-yaml"
+            ],
+            "id": "T_panel"
+        },
+        {
             "path": "T_panel/T_panel.json",
             "step": "case_config",
             "format": "json",


### PR DESCRIPTION
## Description
*This PR adds Balsamic QC metrics tag for Vogue and delivery*

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-hermes-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
