### PR TITLE
changed BALSAMIC tag: PNG plots delivered as a PDF file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [1.5.8]
+### Changed
+-  BALSAMICs ascatngs tag (PNG plots) has been changed to the one of the output PDF
+
 ## [1.5.7]
 ### Added
 - Added BALSAMIC ascatNgs and Delly tags and updated outdated tags

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -36,57 +36,27 @@ BALSAMIC_COMMON_TAGS = {
         "used_by": ["deliver"],
     },
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all", "cnv"}): {
-        "tags": ["ascat-ngs", "vcf", "somatic"],
+        "tags": ["ascatngs", "vcf", "somatic"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all-index", "cnv"}): {
-        "tags": ["ascat-ngs", "vcf-index", "somatic"],
+        "tags": ["ascatngs", "vcf-index", "somatic"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
     frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {
-        "tags": ["ascat-ngs", "vcf", "filtered"],
+        "tags": ["ascatngs", "vcf", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
     frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {
-        "tags": ["ascat-ngs", "vcf-index", "filtered"],
+        "tags": ["ascatngs", "vcf-index", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
-    frozenset({"ascat-ngs-samplestatistics", "samplestatistics"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"aspcfplot", "ascat-ngs-aspcfplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-germlineplot", "germlineplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-rawprofileplot", "rawprofileplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"sunriseplot", "ascat-ngs-sunriseplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"tumorplot", "ascat-ngs-tumorplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": False,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-ascatprofileplot", "ascatprofileplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
+    frozenset({"ascat-output-pdf", "research-ascat-output-pdf"}): {
+        "tags": ["ascatngs", "visualization"],
         "is_mandatory": False,
         "used_by": ["scout", "deliver"],
     },
@@ -420,57 +390,27 @@ TUMOR_NORMAL_WGS_TAGS = {
         "is_mandatory": True
     },
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all", "cnv"}): {
-        "tags": ["ascat-ngs", "vcf", "somatic"],
+        "tags": ["ascatngs", "vcf", "somatic"],
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all-index", "cnv"}): {
-        "tags": ["ascat-ngs", "vcf-index", "somatic"],
+        "tags": ["ascatngs", "vcf-index", "somatic"],
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
     frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {
-        "tags": ["ascat-ngs", "vcf", "filtered"],
+        "tags": ["ascatngs", "vcf", "filtered"],
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
     frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {
-        "tags": ["ascat-ngs", "vcf-index", "filtered"],
+        "tags": ["ascatngs", "vcf-index", "filtered"],
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
-    frozenset({"ascat-ngs-samplestatistics", "samplestatistics"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"aspcfplot", "ascat-ngs-aspcfplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-germlineplot", "germlineplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-rawprofileplot", "rawprofileplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"sunriseplot", "ascat-ngs-sunriseplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"tumorplot", "ascat-ngs-tumorplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
-        "is_mandatory": True,
-        "used_by": ["scout", "deliver"],
-    },
-    frozenset({"ascat-ngs-ascatprofileplot", "ascatprofileplot"}): {
-        "tags": ["ascat-ngs", "visualization"],
+    frozenset({"ascat-output-pdf", "research-ascat-output-pdf"}): {
+        "tags": ["ascatngs", "visualization"],
         "is_mandatory": True,
         "used_by": ["scout", "deliver"],
     },

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -119,7 +119,7 @@ TOOLS = {
     "chanjo": {"description": "Tool to keep track of coverage over specific regions"},
     "chromograph": {"description": "Tool to create PNG images from BED and WIG files from mikaell"},
     "cnvkit": {"description": "Tool to call copy number variations"},
-    "ascat-ngs": {"description": "Tool to identify somatically acquired copy-number alterations"},
+    "ascatngs": {"description": "Tool to identify somatically acquired copy-number alterations"},
     "delly": {"description": "Cancer structural variant prediction tool"},
     "cyrius": {"description": "Tool to call the problematic CYP2D6 gene"},
     "deseq2": {"description": "Differential expression analysis with DESeq2"},

--- a/docs/all_tags.md
+++ b/docs/all_tags.md
@@ -68,7 +68,7 @@
 | chanjo           | Tool to keep track of coverage over specific regions          |
 | chromograph      | Tool to create PNG images from BED and WIG files from mikaell |
 | cnvkit           | Tool to call copy number variations                           |
-| ascat-ngs        | Tool to identify somatically acquired copy-number alterations |
+| ascatngs         | Tool to identify somatically acquired copy-number alterations |
 | delly            | Structural variant prediction tool                            |
 | cyrius           | Tool to call the problematic CYP2D6 gene                      |
 | deseq2           | Differential expression analysis with DESeq2                  |

--- a/docs/balsamic_map.md
+++ b/docs/balsamic_map.md
@@ -6,11 +6,11 @@
 | diagram, cnv-diagram                                               | True        | cnvkit, visualization, diagram                               | deliver               |
 | gene-breaks, cnv-gene-breaks                                       | True        | cnvkit, genes                                                | storage               |
 | cnv-gene-metrics, gene-metrics                                     | True        | cnvkit, genes, metrics                                       | deliver               |
-| ascat, vcf-all, annotated-somatic-vcf-all, cnv                     | True        | ascat-ngs, vcf, somatic                                      | deliver               |
-| ascat, vcf-all, annotated-somatic-vcf-all-index, cnv               | True        | ascat-ngs, vcf-index, somatic                                | deliver               |
-| research-vcf-sv-pass, vcf-sv-pass                                  | True        | ascat-ngs, vcf, filtered, somatic                            | deliver               |
-| research-vcf-sv-pass-index, vcf-sv-pass                            | True        | ascat-ngs, vcf-index, filtered, somatic                      | deliver               |
-| ascat-ngs                                                          | True        | ascat-ngs, visualization                                     | scout, deliver        |
+| ascat, vcf-all, annotated-somatic-vcf-all, cnv                     | True        | ascatngs, vcf, somatic                                       | deliver               |
+| ascat, vcf-all, annotated-somatic-vcf-all-index, cnv               | True        | ascatngs, vcf-index, somatic                                 | deliver               |
+| research-vcf-sv-pass, vcf-sv-pass                                  | True        | ascatngs, vcf, filtered, somatic                             | deliver               |
+| research-vcf-sv-pass-index, vcf-sv-pass                            | True        | ascatngs, vcf-index, filtered, somatic                       | deliver               |
+| ascat-output-pdf, research-ascat-output-pdf                        | True        | ascatngs, visualization                                      | scout, deliver        |
 | delly, annotated-somatic-vcf-all, sv, vcf-all                      | True        | delly, vcf, somatic                                          | deliver               |
 | delly, annotated-somatic-vcf-all-index, sv, vcf-all                | True        | delly, vcf-index, somatic                                    | deliver               |
 | sv, vcf-sv-pass, research-vcf-sv-pass                              | True        | delly, vcf, filtered, somatic                                | deliver               |

--- a/tests/fixtures/balsamic/TN_wgs.hk
+++ b/tests/fixtures/balsamic/TN_wgs.hk
@@ -631,82 +631,16 @@
             "format": "vcf.gz.tbi"
         },
         {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.ascatprofile.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
+            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.output.pdf",
+            "path_index": [],
+            "step": "ascat_tumor_normal_merge_output",
             "tag": [
-                "ascat-ngs-ascatprofileplot",
-                "ascatprofileplot"
+                "ascat-output-pdf",
+                "research-ascat-output-pdf"
             ],
             "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.ASPCF.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "aspcfplot",
-                "ascat-ngs-aspcfplot"
-            ],
-            "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.germline.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "ascat-ngs-germlineplot",
-                "germlineplot"
-            ],
-            "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.rawprofile.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "ascat-ngs-rawprofileplot",
-                "rawprofileplot"
-            ],
-            "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.sunrise.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "sunriseplot",
-                "ascat-ngs-sunriseplot"
-            ],
-            "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.tumor.png",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "tumorplot",
-                "ascat-ngs-tumorplot"
-            ],
-            "id": "TN_WGS",
-            "format": "png"
-        },
-        {
-            "path": "TN_WGS/analysis/vcf/CNV.somatic.TN_WGS.ascat.samplestatistics.txt",
-            "path_index": "",
-            "step": "ascat_tumor_normal",
-            "tag": [
-                "ascat-ngs-samplestatistics",
-                "samplestatistics"
-            ],
-            "id": "TN_WGS",
-            "format": "txt"
-        },
+            "format": "pdf"
+    },
         {
             "path": "TN_WGS/analysis/vep/SV.somatic.TN_WGS.delly.all.vcf.gz",
             "path_index": [


### PR DESCRIPTION
## Description
BALSAMICs ascatngs tag (PNG plots) has been changed to the one of the output PDF.

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-hermes-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
