### PR TITLE
fix: Mantas filtered/passed vcf storage for WGS analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [1.6.7]
+### Fixed
+- Mantas filtered/passed vcf storage for WGS analysis
+
 ## [1.6.6]
 ### Changed
 - Fixes changelog versions

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -351,6 +351,16 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": ["scout", "deliver"],
     },
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass"}): {
+        "tags": ["vcf", "vcf-sv-clinical", "somatic"],
+        "is_mandatory": False,
+        "used_by": ["scout", "deliver"],
+    },
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index"}): {
+        "tags": ["vcf-index", "vcf-sv-clinical-index", "somatic"],
+        "is_mandatory": False,
+        "used_by": ["scout", "deliver"],
+    },
 }
 
 TUMOR_ONLY_WGS_TAGS = {
@@ -367,8 +377,8 @@ TUMOR_ONLY_WGS_TAGS = {
     frozenset({"clinical-vcf-filtered-index", "snv", "vcf-filtered"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass", "snv"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass-index", "snv"}): {"is_mandatory": True},
-    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass", "sv"}): {"is_mandatory": False},
-    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index", "sv"}): {"is_mandatory": False},
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass"}): {"is_mandatory": False},
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index"}): {"is_mandatory": False},
 }
 
 TUMOR_NORMAL_WGS_TAGS = {
@@ -380,8 +390,8 @@ TUMOR_NORMAL_WGS_TAGS = {
     frozenset({"clinical-vcf-filtered-index", "snv", "vcf-filtered"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass", "snv"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass-index", "snv"}): {"is_mandatory": True},
-    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass", "sv"}): {"is_mandatory": False},
-    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index", "sv"}): {"is_mandatory": False},
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass"}): {"is_mandatory": False},
+    frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index"}): {"is_mandatory": False},
     frozenset({"tnscope", "snv", "annotated-somatic-vcf-all", "vcf-all"}): {"is_mandatory": True},
     frozenset({"tnscope", "snv", "annotated-somatic-vcf-all-index", "vcf-all"}): {
         "is_mandatory": True

--- a/tests/fixtures/balsamic/TN_wgs.hk
+++ b/tests/fixtures/balsamic/TN_wgs.hk
@@ -313,10 +313,9 @@
             "path_index": [
                 "TN_WGS/analysis/vep/SV.somatic.TN_WGS.manta.all.filtered.pass.vcf.gz.tbi"
             ],
-            "step": "ngs_filter_manta",
+            "step": "bcftools_filter_manta",
             "tag": [
                 "clinical-vcf-sv-pass",
-                "SV",
                 "vcf-sv-pass",
                 "TN-WGS"
             ],
@@ -326,10 +325,9 @@
         {
             "path": "TN_WGS/analysis/vep/SV.somatic.TN_WGS.manta.all.filtered.pass.vcf.gz.tbi",
             "path_index": "",
-            "step": "ngs_filter_manta",
+            "step": "bcftools_filter_manta",
             "tag": [
                 "clinical-vcf-sv-pass-index",
-                "SV",
                 "vcf-sv-pass",
                 "TN-WGS"
             ],


### PR DESCRIPTION
## Description
*Deletes the mantas filtered/passed vcf residual tag (`sv`) for WGS analysis*

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-hermes-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
