### PR TITLE
refactor:  Workaround to deliver delly and ascat vcfs (same BALSAMIC tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [1.6.11]
+### Fixed
+- Workaround to deliver delly and ascat vcfs as a result of producing Balsamic the same labels for both of them
+
+## [1.6.10]
+
 ## [1.6.9]
 ### Added
 - cnvkit filtered vcf tags

--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -45,13 +45,13 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
-    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {
-        "tags": ["ascatngs", "vcf-sv-research", "filtered"],
+    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {  # ascat & delly WGS
+        "tags": ["vcf-sv-research", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
     frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {
-        "tags": ["ascatngs", "vcf-sv-research-index", "filtered"],
+        "tags": ["vcf-sv-research-index", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
@@ -70,23 +70,13 @@ BALSAMIC_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": ["deliver"],
     },
-    frozenset({"sv", "vcf-sv-pass", "research-vcf-sv-pass"}): {
-        "tags": ["delly", "vcf", "filtered", "somatic"],
+    frozenset({"sv", "vcf-sv-pass", "research-vcf-sv-pass"}): {  # delly PANEL
+        "tags": ["vcf-sv-research", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
     frozenset({"sv", "vcf-sv-pass", "research-vcf-sv-pass-index"}): {
-        "tags": ["delly", "vcf-index", "filtered", "somatic"],
-        "is_mandatory": False,
-        "used_by": ["deliver"],
-    },
-    frozenset({"vcf-sv-pass", "research-vcf-sv-pass"}): {
-        "tags": ["delly", "vcf", "filtered", "somatic"],
-        "is_mandatory": False,
-        "used_by": ["deliver"],
-    },
-    frozenset({"vcf-sv-pass", "research-vcf-sv-pass-index"}): {
-        "tags": ["delly", "vcf-index", "filtered", "somatic"],
+        "tags": ["vcf-sv-research-index", "filtered"],
         "is_mandatory": False,
         "used_by": ["deliver"],
     },
@@ -387,6 +377,8 @@ TUMOR_ONLY_WGS_TAGS = {
     frozenset({"clinical-vcf-filtered-index", "snv", "vcf-filtered"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass", "snv"}): {"is_mandatory": True},
     frozenset({"vcf-pass", "clinical-vcf-pass-index", "snv"}): {"is_mandatory": True},
+    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {"is_mandatory": False},  # delly WGS
+    frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {"is_mandatory": False},
     frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass"}): {"is_mandatory": False},
     frozenset({"vcf-sv-pass", "clinical-vcf-sv-pass-index"}): {"is_mandatory": False},
 }
@@ -407,8 +399,8 @@ TUMOR_NORMAL_WGS_TAGS = {
     frozenset({"tnscope", "snv", "vcf-summary", "annotated-somatic-vcf-summary"}): {"is_mandatory": True},
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all", "cnv"}): {"is_mandatory": True},
     frozenset({"ascat", "vcf-all", "annotated-somatic-vcf-all-index", "cnv"}): {"is_mandatory": True},
-    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {"is_mandatory": True},
-    frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {"is_mandatory": True},
+    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {"is_mandatory": False}, # ascat & delly WGS
+    frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {"is_mandatory": False},
     frozenset({"ascat-output-pdf", "research-ascat-output-pdf"}): {"is_mandatory": True},
 }
 
@@ -505,6 +497,8 @@ TUMOR_ONLY_PANEL_TAGS = {
     },
     frozenset({"research-vcf-sv-pass", "vcf-sv-pass", "cnv"}): {"is_mandatory": True},
     frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass", "cnv"}): {"is_mandatory": True},
+    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {"is_mandatory": False},  # delly PANEL
+    frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {"is_mandatory": False},
 }
 
 TUMOR_NORMAL_PANEL_TAGS = {
@@ -602,4 +596,6 @@ TUMOR_NORMAL_PANEL_TAGS = {
     },
     frozenset({"research-vcf-sv-pass", "vcf-sv-pass", "cnv"}): {"is_mandatory": True},
     frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass", "cnv"}): {"is_mandatory": True},
+    frozenset({"research-vcf-sv-pass", "vcf-sv-pass"}): {"is_mandatory": False},  # delly PANEL
+    frozenset({"research-vcf-sv-pass-index", "vcf-sv-pass"}): {"is_mandatory": False},
 }


### PR DESCRIPTION
## Description
Workaround to deliver delly and ascat vcfs as a result of producing Balsamic the same labels for both of them

### How to prepare for test
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] paxa the environment: `paxa`
- [x] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-hermes-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [x] `hermes validate deliverables --pipeline balsamic --analysis-type tumor_normal_wgs /home/proj/production/cancer/cases/selectprawn/analysis/delivery_report/selectprawn.hk `

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
