### PR TITLE
hotfix: umi cram tags

### DIFF
--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -362,22 +362,22 @@ BALSAMIC_COMMON_TAGS = {
         "used_by": ["deliver"],
     },
     frozenset({"cram", "umi-tumor-cram"}): {
-        "tags": ["umi", "cram", "tumor"],
+        "tags": ["umi-cram", "tumor"],
         "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset({"cram", "umi-tumor-cram-index"}): {
-        "tags": ["umi", "cram-index", "tumor"],
+        "tags": ["umi-cram-index", "tumor"],
         "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset({"cram", "umi-normal-cram"}): {
-        "tags": ["umi", "cram", "normal"],
+        "tags": ["umi-cram", "normal"],
         "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset({"cram", "umi-normal-cram-index"}): {
-        "tags": ["umi", "cram-index", "normal"],
+        "tags": ["umi-cram-index", "normal"],
         "is_mandatory": False,
         "used_by": ["storage"],
     },

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -112,7 +112,9 @@ ANALYSIS_COMMON = {
     "tcov": {"description": "Coverage output"},
     "tiddit-coverage": {"description": "Coverage output from tiddit"},
     "visualization": {"description": "Visualizes data"},
-    "umi": {"description": "Files related to UMI workflow"}
+    "umi": {"description": "Files related to UMI workflow"},
+    "umi-cram": {"description": "UMI consensus filtered cram file"},
+    "umi-cram-index": {"description": "Index for the UMI consensus filtered cram file"}
 }
 
 TOOLS = {


### PR DESCRIPTION
## Description
Fixes unexpected behaviour of UMI cram being included in the scout yaml file despite not having the `scout` tag.

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] paxa the environment: `paxa`
- [ ] install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-hermes-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
