### PR TITLE
Update rnafusion tags

### DIFF
--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -61,7 +61,7 @@ RNAFUSION_COMMON_TAGS = {
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
-        "tags": ["multiqc-html"],
+        "tags": ["multiqc-html", "rna"],
         "used_by": ["deliver", "scout"],
     },
 }

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -16,7 +16,7 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"arriba-visualisation", "arriba"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["arriba-visualisation", "visualization", "arriba"],
+        "tags": ["arriba-visualisation", "visualization", "arriba", "research"],
         "used_by": ["deliver", "scout"],
     },
     frozenset({"fusioncatcher"}): {
@@ -46,7 +46,7 @@ RNAFUSION_COMMON_TAGS = {
     },
     frozenset({"fusionreport", "report"}): {
         "is_mandatory": True,
-        "tags": ["fusionreport"],
+        "tags": ["fusionreport", "research"],
         "used_by": ["deliver", "scout"],
     },
     frozenset({"fusioninspector", "report"}): {
@@ -56,7 +56,7 @@ RNAFUSION_COMMON_TAGS = {
     },
     frozenset({"fusioninspector-html", "report"}): {
         "is_mandatory": True,
-        "tags": ["fusioninspector-html"],
+        "tags": ["fusioninspector-html", "research"],
         "used_by": ["deliver", "scout"]
     },
     frozenset({"multiqc-html", "report"}): {

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -11,53 +11,58 @@ RNAFUSION_COMMON_TAGS = {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": ["arriba", "fusion"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"arriba-visualisation", "arriba"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": ["arriba-visualisation", "visualization", "arriba"],
-        "used_by": ["cg"],
+        "used_by": ["deliver", "scout"],
     },
     frozenset({"fusioncatcher"}): {
         "is_mandatory": True,
         "tags": ["fusioncatcher", "fusion"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"fusioncatcher-summary", "fusioncatcher"}): {
         "is_mandatory": True,
         "tags": ["fusioncatcher-summary"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"pizzly"}): {
         "is_mandatory": True,
         "tags": ["pizzly", "fusion"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"star-fusion"}): {
         "is_mandatory": True,
         "tags": ["star-fusion", "fusion"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"squid"}): {
         "is_mandatory": True,
         "tags": ["squid", "fusion"],
-        "used_by": ["cg"],
+        "used_by": ["deliver"],
     },
     frozenset({"fusionreport", "report"}): {
         "is_mandatory": True,
         "tags": ["fusionreport"],
-        "used_by": ["cg"],
+        "used_by": ["deliver", "scout"],
     },
     frozenset({"fusioninspector", "report"}): {
         "is_mandatory": True,
         "tags": ["fusioninspector"],
-        "used_by": ["cg"]
+        "used_by": ["deliver"]
+    },
+    frozenset({"fusioninspector-html", "report"}): {
+        "is_mandatory": True,
+        "tags": ["fusioninspector-html"],
+        "used_by": ["deliver", "scout"]
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
         "tags": ["multiqc-html"],
-        "used_by": ["deliver"],
+        "used_by": ["deliver", "scout"],
     },
 }
 

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -230,6 +230,7 @@ MUTANT_SPECIFIC = {
 RNAFUSION_SPECIFIC = {
     "arriba-visualisation": {"description": "Arriba visualization"},
     "fusionreport": {"description": "Fusion-report analysis"},
+    "fusioninspector-html": {"description": "Fusioninspector report"},
 }
 
 NEXTFLOW_SPECIFIC = {

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -22,6 +22,7 @@ RAW_DATA = {
     "forward-strand": {"description": "Reads from forward strand"},
     "reverse-strand": {"description": "Reads from reverse strand"},
     "unpaired-reads": {"description": "Reads that could not be paired"},
+    "rna": {"description": "Data generated from RNA samples"},
 }
 
 

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -2,7 +2,7 @@
 |----------------------------------------------------------------|-------------|---------------------------------------------|-----------------------|
 | arriba                                                         | True        | fusion, arriba                              | deliver               |
 | pizzly                                                         | True        | fusion, pizzly                              | deliver               |
-| starfusions                                                    | True        | fusion, star-fusion                         | deliver               |
+| star-fusion                                                    | True        | fusion, star-fusion                         | deliver               |
 | squid                                                          | True        | fusion, squid                               | deliver               |
 | fusioncatcher                                                  | True        | fusion, fusioncatcher                       | deliver               |
 | fusioncatcher-summary, fusioncatcher                           | True        | fusioncatcher-summary                       | deliver               |

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -11,5 +11,5 @@
 | fusioninspector-html, report                                   | True        | fusioninspector-html                        | deliver, scout        |
 | arriba-visualisation, arriba                                   | True        | visualization, arriba, arriba-visualisation | deliver, scout        |  
 | multiqc-html, report                                           | True        | multiqc-html, rna                           | deliver, scout        |  
-| samplesheet-valid                                              | True        | samplesheet-valid                           | deliver               |  
-| software-versions                                              | True        | software-versions                           | deliver               |  
+| samplesheet-valid                                              | True        | samplesheet-valid                           | cg               |  
+| software-versions                                              | True        | software-versions                           | cg               |  

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -1,8 +1,15 @@
-| Rnafusion tags                                                 | Mandatory   | HK tags                                 | Used by               |
-|----------------------------------------------------------------|-------------|-----------------------------------------|-----------------------|
-| arriba_fusions                                                 | True        | arriba                                  | cg                    |
-| fusioncatcher_fusions                                          | True        | fusioncatcher                           | cg                    |
-| fusioncatcher_summary                                          | False       | fusioncatcher_summary                   | cg                    |
-| pizzly_fusions                                                 | True        | pizzly                                  | cg                    |
-| starfusions_fusions                                            | True        | star-fusion                             | cg                    |
-| squid_fusions                                                  | True        | squid                                   | cg                    |
+| Rnafusion tags                                                 | Mandatory   | HK tags                                     | Used by               |
+|----------------------------------------------------------------|-------------|---------------------------------------------|-----------------------|
+| arriba                                                         | True        | fusion, arriba                              | deliver               |
+| pizzly                                                         | True        | fusion, pizzly                              | deliver               |
+| starfusions                                                    | True        | fusion, star-fusion                         | deliver               |
+| squid                                                          | True        | fusion, squid                               | deliver               |
+| fusioncatcher                                                  | True        | fusion, fusioncatcher                       | deliver               |
+| fusioncatcher-summary, fusioncatcher                           | True        | fusioncatcher-summary                       | deliver               |
+| fusioninspector, report                                        | True        | fusioninspector                             | deliver               |  
+| fusionreport, report                                           | True        | fusionreport                                | deliver, scout        |
+| fusioninspector-html, report                                   | True        | fusioninspector-html                        | deliver, scout        |
+| arriba-visualisation, arriba                                   | True        | visualization, arriba, arriba-visualisation | deliver, scout        |  
+| multiqc-html, report                                           | True        | multiqc-html                                | deliver, scout        |  
+| samplesheet-valid                                              | True        | samplesheet-valid                           | deliver               |  
+| software-versions                                              | True        | software-versions                           | deliver               |  

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -10,6 +10,6 @@
 | fusionreport, report                                           | True        | fusionreport                                | deliver, scout        |
 | fusioninspector-html, report                                   | True        | fusioninspector-html                        | deliver, scout        |
 | arriba-visualisation, arriba                                   | True        | visualization, arriba, arriba-visualisation | deliver, scout        |  
-| multiqc-html, report                                           | True        | multiqc-html                                | deliver, scout        |  
+| multiqc-html, report                                           | True        | multiqc-html, rna                           | deliver, scout        |  
 | samplesheet-valid                                              | True        | samplesheet-valid                           | deliver               |  
 | software-versions                                              | True        | software-versions                           | deliver               |  

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -7,9 +7,9 @@
 | fusioncatcher                                                  | True        | fusion, fusioncatcher                       | deliver               |
 | fusioncatcher-summary, fusioncatcher                           | True        | fusioncatcher-summary                       | deliver               |
 | fusioninspector, report                                        | True        | fusioninspector                             | deliver               |  
-| fusionreport, report                                           | True        | fusionreport                                | deliver, scout        |
-| fusioninspector-html, report                                   | True        | fusioninspector-html                        | deliver, scout        |
-| arriba-visualisation, arriba                                   | True        | visualization, arriba, arriba-visualisation | deliver, scout        |  
+| fusionreport, report                                           | True        | fusionreport, research                                | deliver, scout        |
+| fusioninspector-html, report                                   | True        | fusioninspector-html, research                        | deliver, scout        |
+| arriba-visualisation, arriba                                   | True        | visualization, arriba, arriba-visualisation, research | deliver, scout        |  
 | multiqc-html, report                                           | True        | multiqc-html, rna                           | deliver, scout        |  
 | samplesheet-valid                                              | True        | samplesheet-valid                           | cg               |  
 | software-versions                                              | True        | software-versions                           | cg               |  

--- a/tests/fixtures/rnafusion/case_id_deliverables.yaml
+++ b/tests/fixtures/rnafusion/case_id_deliverables.yaml
@@ -47,6 +47,12 @@ files:
   path_index: ~
   step: report
   tag: fusioninspector
+- format: html
+  id: solidfawn
+  path: /path/to/rnafusion/cases/case_id/fusioninspector/solidfawn.fusion_inspector_web.html
+  path_index: ~
+  step: report
+  tag: fusioninspector-html
 - format: pdf
   id: solidfawn
   path: /path/to/rnafusion/cases/case_id/arriba_visualisation/solidfawn.pdf


### PR DESCRIPTION
## Description

This PR updates rnafusion tags

### How to prepare for test
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b fix_rnafusion_tags`

### How to test
- [x] `housekeeper get bundle -v cuddlyhen`. Check that tags are correct.

<img width="1500" alt="image" src="https://user-images.githubusercontent.com/29628428/217241217-6afe1cbd-62de-44c9-b65e-794311697588.png">




## Review
- [x] Tests executed by EFC
- [x] "Merge and deploy" approved by VI
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
