### PR TITLE
adds tags for mobile elements

### DIFF
--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -103,19 +103,19 @@ MIP_DNA_TAGS = {
     },
     frozenset(["me_merge_vcfs"]): {
         "tags": ["retroseq", "vcf"],
-        "tags": ["retroseq", "vcf-index"],
+        "index_tags": ["retroseq", "vcf-index"],
         "is_mandatory": False,
         "used_by": ["audit"],
     },
     frozenset(["me_filter", "clinical"]): {
         "tags": ["mobile-elements", "clinical", "vcf"],
-        "tags": ["mobile-elements", "clinical", "vcf-index"],
+        "index_tags": ["mobile-elements", "clinical", "vcf-index"],
         "is_mandatory": False,
         "used_by": ["scout"],
     },
     frozenset(["me_filter", "research"]): {
         "tags": ["mobile-elements", "research", "vcf"],
-        "tags": ["mobile-elements", "research", "vcf-index"],
+        "index_tags": ["mobile-elements", "research", "vcf-index"],
         "is_mandatory": False,
         "used_by": ["scout"],
     },

--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -101,6 +101,24 @@ MIP_DNA_TAGS = {
         "is_mandatory": False,
         "used_by": ["scout"],
     },
+    frozenset(["me_merge_vcfs"]): {
+        "tags": ["retroseq", "vcf"],
+        "tags": ["retroseq", "vcf-index"],
+        "is_mandatory": False,
+        "used_by": ["audit"],
+    },
+    frozenset(["me_filter", "clinical"]): {
+        "tags": ["mobile-elements", "clinical", "vcf"],
+        "tags": ["mobile-elements", "clinical", "vcf-index"],
+        "is_mandatory": False,
+        "used_by": ["scout"],
+    },
+    frozenset(["me_filter", "research"]): {
+        "tags": ["mobile-elements", "research", "vcf"],
+        "tags": ["mobile-elements", "research", "vcf-index"],
+        "is_mandatory": False,
+        "used_by": ["scout"],
+    },
     frozenset(["mip_analyse", "config"]): {
         "tags": ["mip-analyse", "config"],
         "is_mandatory": True,

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -28,6 +28,7 @@ RAW_DATA = {
 
 VARIANT_COMMON = {
     "cnv": {"description": "Copy number variants"},
+    "mobile-elements": {"description": "Mobile elements"},
     "normal": {"description": "Associated with normal sample"},
     "germline": {"description": "Associated with germline variants"},
     "somatic": {"description": "Associated with somatic variants"},
@@ -166,6 +167,7 @@ TOOLS = {
     "peddy": {"description": "Tool to check pedigree and ancestral relations"},
     "picard": {"description": "Picard set of bioinformatic tools"},
     "pizzly": {"description": "Fusion caller"},
+    "retroseq": {"description": "Mobile element caller"},
     "salmon-quant": {"description": "Transcript quantification"},
     "sention": {"description": "Sention algorithm"},
     "squid": {"description": "Fusion caller"},

--- a/docs/all_tags.md
+++ b/docs/all_tags.md
@@ -102,6 +102,7 @@
 | mitodel          | Tool to identify mitochondrial deletion signatures            |
 | peddy            | Tool to check pedigree and ancestral relations                |
 | picard           | Picard set of bioinformatic tools                             |
+| retroseq          | Tool to call mobile elements                             |
 | salmon-quant     | Transcript quantification                                     |
 | sention          | Sention algorithm                                             |
 | star-fusion      | Fusion caller                                                 |
@@ -127,6 +128,7 @@
 | Tag name                   | Description                                         |
 |----------------------------|-----------------------------------------------------|
 | cnv                        | Copy number variants                                |
+| mobile-elements            | Mobile elements                                     |
 | normal                     | Associated with normal sample                       |
 | germline                   | Associated with germline variants                   |
 | somatic                    | Associated with somatic variants                    |

--- a/docs/all_tags.md
+++ b/docs/all_tags.md
@@ -44,7 +44,7 @@
 | qc-cram         | QC alignment file in CRAM format                |
 | qc-cram-index   | QC index file for alignment file in CRAM format |
 
-## FAMILY TAGS
+## CASE TAGS
 
 | Tag name | Description          |
 | -------- | -------------------- |

--- a/docs/all_tags.md
+++ b/docs/all_tags.md
@@ -1,7 +1,7 @@
 ## ALIGNMENT TAGS
 
 | Tag name   | Description                                                |
-|------------|------------------------------------------------------------|
+| ---------- | ---------------------------------------------------------- |
 | bam        | Alignment file in BAM format                               |
 | bam-index  | Index file for alignment file in BAM format                |
 | bam-mt     | Alignment file in BAM format holding the reaads from chrMT |
@@ -11,7 +11,7 @@
 ## ANALYSIS TAGS
 
 | Tag name        | Description                                     |
-|-----------------|-------------------------------------------------|
+| --------------- | ----------------------------------------------- |
 | assembly        | Assembly                                        |
 | autozyg         | Autozygous region                               |
 | bed             | Bed file                                        |
@@ -46,15 +46,15 @@
 
 ## FAMILY TAGS
 
-| Tag name   | Description          |
-|------------|----------------------|
-| pedigree   | Pedigree information |
-| ped        | Pedigree information |
+| Tag name | Description          |
+| -------- | -------------------- |
+| pedigree | Pedigree information |
+| ped      | Pedigree information |
 
 ## RAW DATA
 
 | Tag name       | Description                         |
-|----------------|-------------------------------------|
+| -------------- | ----------------------------------- |
 | fastq          | Files with raw data in fastq format |
 | fasta          | Files with raw data in fasta format |
 | forward-strand | Reads from forward strand           |
@@ -64,7 +64,7 @@
 ## REPORTING TAGS
 
 | Tag name          | Description                                     |
-|-------------------|-------------------------------------------------|
+| ----------------- | ----------------------------------------------- |
 | audit             | Audit file                                      |
 | csv               | Comma separated values                          |
 | deliverable       | Deliverables file                               |
@@ -82,7 +82,7 @@
 ## TOOL TAGS
 
 | Tag name         | Description                                                   |
-|------------------|---------------------------------------------------------------|
+| ---------------- | ------------------------------------------------------------- |
 | arriba           | Fusion caller                                                 |
 | asereadcounter   | Count reads mapping to heterozygous sites                     |
 | chanjo           | Tool to keep track of coverage over specific regions          |
@@ -102,7 +102,7 @@
 | mitodel          | Tool to identify mitochondrial deletion signatures            |
 | peddy            | Tool to check pedigree and ancestral relations                |
 | picard           | Picard set of bioinformatic tools                             |
-| retroseq          | Tool to call mobile elements                             |
+| retroseq         | Tool to call mobile elements                                  |
 | salmon-quant     | Transcript quantification                                     |
 | sention          | Sention algorithm                                             |
 | star-fusion      | Fusion caller                                                 |
@@ -118,7 +118,7 @@
 ## VALIDATION TAGS
 
 | Tag name   | Description                      |
-|------------|----------------------------------|
+| ---------- | -------------------------------- |
 | ped-check  | Results from pedigree validation |
 | qc-metrics | QC metrics from analysis         |
 | sex-check  | Results from sex validation      |
@@ -126,7 +126,7 @@
 ## VARIANT TAGS
 
 | Tag name                   | Description                                         |
-|----------------------------|-----------------------------------------------------|
+| -------------------------- | --------------------------------------------------- |
 | cnv                        | Copy number variants                                |
 | mobile-elements            | Mobile elements                                     |
 | normal                     | Associated with normal sample                       |

--- a/docs/mip-dna_map.md
+++ b/docs/mip-dna_map.md
@@ -1,46 +1,49 @@
-| Mip-dna tags                        | Mandatory   | HK tags                     | Used by      |
-|-------------------------------------|-------------|-----------------------------|--------------|
-| chanjo_sexcheck                     | False       | chanjo, sex-check           | scout        |
-| chromograph_cov, tcov               | False       | chromograph, tcov           | scout        |
-| clinical, endvariantannotationblock | True        | vcf-snv-clinical            | scout        |
-| clinical, sv_reformat               | False       | vcf-sv-clinical             | scout        |
-| config, mip_analyse                 | True        | mip-analyse, config         | cg, audit    |
-| config_analysis, mip_analyse        | True        | mip-config                  | cg, audit    |
-| coverage, sambamba_depth            | True        | coverage, sambamba-depth    | chanjo       |
-| expansionhunter, str_alignments     | False       | expansionhunter, bam        | scout        |
-| expansionhunter, str_variants       | False       | expansionhunter, vcf-str    | scout        |
-| expansionhunter, variant_catalog    | False       | expansionhunter, variant-catalog    | scout        |
-| gatk_baserecalibration              | False       | cram                        | scout        |
-| gatk_combinevariantcallsets         | True        | snv-gbcf, snv-bcf           | genotype     |
-| gens_generatedata, baf              | False       | gens, fracsnp               | scout        |
-| gens_generatedata, cov              | False       | gens, coverage              | scout        |
-| glnexus_merge                       | False       | deepvariant, snv, vcf       | storage      |
-| html, multiqc_ar                    | True        | multiqc-html                | scout        |
-| json, multiqc_ar                    | True        | multiqc-json                | vogue        |
-| log, mip_analyse                    | True        | mip-log                     | audit        |
-| mitodel                             | False       | mitodel                     | scout        |
-| peddy, peddy_ar                     | True        | peddy, ped                  | audit, scout |
-| peddy_ar, ped_check                 | True        | peddy, ped-check            | audit, scout |
-| pedigree, mip_analyse               | True        | pedigree-yaml               | audit        |
-| pedigree_fam, mip_analyse           | True        | pedigree                    | scout        |
-| qccollect_ar, audit                 | True        | qc-metrics, audit           | audit        |
-| qccollect_ar, deliverable           | True        | qc-metrics, deliverable    | audit        |
-| references_info, mip_analyse        | True        | mip-analyse, reference-info | audit        |
-| regions, chromograph_upd            | False       | chromograph, upd, regions   | scout        |
-| research, endvariantannotationblock | True        | vcf-snv-research            | scout        |
-| research, sv_reformat               | False       | vcf-sv-research             | scout        |
-| rhocall_viz                         | False       | rhocall-viz                 | scout        |
-| sample_info, mip_analyse            | True        | sample-info                 | cg, audit    |
-| samtools_subsample_mt               | False       | bam-mt                      | scout        |
-| sex_check, peddy_ar                 | True        | peddy, sex-check            | audit, scout |
-| sites, chromograph_upd              | False       | chromograph, upd, sites     | scout        |
-| sites, upd_ar                       | False       | upd, sites                  | scout        |
-| smncopynumbercaller                 | False       | smn-calling                 | scout        |
-| star_caller                         | False       | cyrius                      | scout        |
-| sv_combinevariantcallsets           | True        | sv-bcf                      | audit        |
-| sv_str, expansionhunter             | False       | vcf-str                     | scout        |
-| telomerecat_ar                      | False       | telomere-calling            | scout        |
-| tiddit_coverage                     | False       | tiddit-coverage, bigwig     | scout        |
-| upd_ar, regions                     | False       | upd, regions                | scout        |
-| vcf2cytosure_ar                     | False       | vcf2cytosure                | scout        |
-| version_collect_ar                  | True        | exe-ver                     | audit        |
+| Mip-dna tags                        | Mandatory | HK tags                          | Used by      |
+| ----------------------------------- | --------- | -------------------------------- | ------------ |
+| chanjo_sexcheck                     | False     | chanjo, sex-check                | scout        |
+| chromograph_cov, tcov               | False     | chromograph, tcov                | scout        |
+| clinical, endvariantannotationblock | True      | vcf-snv-clinical                 | scout        |
+| clinical, me_filter                 | False     | clinical, mobile-elements, vcf   | scout        |
+| clinical, sv_reformat               | False     | vcf-sv-clinical                  | scout        |
+| config, mip_analyse                 | True      | mip-analyse, config              | cg, audit    |
+| config_analysis, mip_analyse        | True      | mip-config                       | cg, audit    |
+| coverage, sambamba_depth            | True      | coverage, sambamba-depth         | chanjo       |
+| expansionhunter, str_alignments     | False     | expansionhunter, bam             | scout        |
+| expansionhunter, str_variants       | False     | expansionhunter, vcf-str         | scout        |
+| expansionhunter, variant_catalog    | False     | expansionhunter, variant-catalog | scout        |
+| gatk_baserecalibration              | False     | cram                             | scout        |
+| gatk_combinevariantcallsets         | True      | snv-gbcf, snv-bcf                | genotype     |
+| gens_generatedata, baf              | False     | gens, fracsnp                    | scout        |
+| gens_generatedata, cov              | False     | gens, coverage                   | scout        |
+| glnexus_merge                       | False     | deepvariant, snv, vcf            | storage      |
+| html, multiqc_ar                    | True      | multiqc-html                     | scout        |
+| json, multiqc_ar                    | True      | multiqc-json                     | vogue        |
+| log, mip_analyse                    | True      | mip-log                          | audit        |
+| me_merge_vcfs                       | False     | retroseq, vcf                    | audit        |
+| mitodel                             | False     | mitodel                          | scout        |
+| peddy, peddy_ar                     | True      | peddy, ped                       | audit, scout |
+| peddy_ar, ped_check                 | True      | peddy, ped-check                 | audit, scout |
+| pedigree, mip_analyse               | True      | pedigree-yaml                    | audit        |
+| pedigree_fam, mip_analyse           | True      | pedigree                         | scout        |
+| qccollect_ar, audit                 | True      | qc-metrics, audit                | audit        |
+| qccollect_ar, deliverable           | True      | qc-metrics, deliverable          | audit        |
+| references_info, mip_analyse        | True      | mip-analyse, reference-info      | audit        |
+| regions, chromograph_upd            | False     | chromograph, upd, regions        | scout        |
+| research, endvariantannotationblock | True      | vcf-snv-research                 | scout        |
+| research, me_filter                 | False     | research, mobile-elements, vcf   | scout        |
+| research, sv_reformat               | False     | vcf-sv-research                  | scout        |
+| rhocall_viz                         | False     | rhocall-viz                      | scout        |
+| sample_info, mip_analyse            | True      | sample-info                      | cg, audit    |
+| samtools_subsample_mt               | False     | bam-mt                           | scout        |
+| sex_check, peddy_ar                 | True      | peddy, sex-check                 | audit, scout |
+| sites, chromograph_upd              | False     | chromograph, upd, sites          | scout        |
+| sites, upd_ar                       | False     | upd, sites                       | scout        |
+| smncopynumbercaller                 | False     | smn-calling                      | scout        |
+| star_caller                         | False     | cyrius                           | scout        |
+| sv_combinevariantcallsets           | True      | sv-bcf                           | audit        |
+| sv_str, expansionhunter             | False     | vcf-str                          | scout        |
+| telomerecat_ar                      | False     | telomere-calling                 | scout        |
+| tiddit_coverage                     | False     | tiddit-coverage, bigwig          | scout        |
+| upd_ar, regions                     | False     | upd, regions                     | scout        |
+| vcf2cytosure_ar                     | False     | vcf2cytosure                     | scout        |
+| version_collect_ar                  | True      | exe-ver                          | audit        |

--- a/tests/fixtures/mip_dna/case_id_deliverables.yaml
+++ b/tests/fixtures/mip_dna/case_id_deliverables.yaml
@@ -130,6 +130,24 @@ files:
     path_index: ~
     step: multiqc_ar
     tag: html
+  - format: vcf
+    id: justhusky
+    path: /home/proj/stage/rare-disease/cases/justhusky/analysis/justhusky/me_merge_vcfs/justhusky_me.vcf.gz
+    path_index: /home/proj/stage/rare-disease/cases/justhusky/analysis/justhusky/me_merge_vcfs/justhusky_me.vcf.gz.tbi
+    step: me_filter
+    tag: ~
+  - format: vcf
+    id: case_id
+    path: /path/to/rare-disease/cases/case_id/analysis/case_id/me_filter/case_id_me_ann_vep_filter.selected.vcf.gz
+    path_index: /path/to/rare-disease/cases/case_id/analysis/case_id/me_filter/case_id_me_ann_vep_filter.selected.vcf.gz.tbi
+    step: me_filter
+    tag: clinica~
+  - format: vcf
+    id: case_id
+    path: /path/to/rare-disease/cases/case_id/analysis/case_id/me_filter/case_id_me_ann_vep_filter.vcf.gz
+    path_index: /path/to/rare-disease/cases/case_id/analysis/case_id/me_filter/case_id_me_ann_vep_filter.vcf.gz.tbi
+    step: me_filter
+    tag: research
   - format: meta
     id: case_id
     path: /path/to/rare-disease/cases/case_id/analysis/case_id/multiqc_ar/multiqc_data/multiqc_data.json


### PR DESCRIPTION
## Description
This PR adds tags for the files generated by the mobile element branch of the MIP DNA workflow

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b retroseq`

### How to test
- [ ] Do `cg workflow mip-dna store justhusky`

### Expected test outcome
- [ ] Check that mobile element files are included
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
