### PR TITLE
Update rnafusion tags

### DIFF
--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -29,19 +29,9 @@ RNAFUSION_COMMON_TAGS = {
         "tags": ["fusioncatcher-summary"],
         "used_by": ["deliver"],
     },
-    frozenset({"pizzly"}): {
-        "is_mandatory": True,
-        "tags": ["pizzly", "fusion"],
-        "used_by": ["deliver"],
-    },
     frozenset({"star-fusion"}): {
         "is_mandatory": True,
         "tags": ["star-fusion", "fusion"],
-        "used_by": ["deliver"],
-    },
-    frozenset({"squid"}): {
-        "is_mandatory": True,
-        "tags": ["squid", "fusion"],
         "used_by": ["deliver"],
     },
     frozenset({"fusionreport", "report"}): {

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -54,6 +54,11 @@ RNAFUSION_COMMON_TAGS = {
         "tags": ["multiqc-html", "rna"],
         "used_by": ["deliver", "scout"],
     },
+    frozenset({"star-fusion-cram", "star-fusion"}): {
+        "is_mandatory": True,
+        "tags": ["cram"],
+        "used_by": ["deliver"],
+    },
 }
 
 NXF_RNAFUSION_COMMON_TAGS = {**RNAFUSION_COMMON_TAGS, **NEXTFLOW_COMMON_TAGS}

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -1,11 +1,10 @@
 | Rnafusion tags                                                 | Mandatory   | HK tags                                     | Used by               |
 |----------------------------------------------------------------|-------------|---------------------------------------------|-----------------------|
 | arriba                                                         | True        | fusion, arriba                              | deliver               |
-| pizzly                                                         | True        | fusion, pizzly                              | deliver               |
 | star-fusion                                                    | True        | fusion, star-fusion                         | deliver               |
-| squid                                                          | True        | fusion, squid                               | deliver               |
 | fusioncatcher                                                  | True        | fusion, fusioncatcher                       | deliver               |
 | fusioncatcher-summary, fusioncatcher                           | True        | fusioncatcher-summary                       | deliver               |
+| star-fusion-cram, star-fusion                           | True        | cram                       | deliver               |
 | fusioninspector, report                                        | True        | fusioninspector                             | deliver               |  
 | fusionreport, report                                           | True        | fusionreport, research                                | deliver, scout        |
 | fusioninspector-html, report                                   | True        | fusioninspector-html, research                        | deliver, scout        |

--- a/tests/fixtures/rnafusion/case_id_deliverables.yaml
+++ b/tests/fixtures/rnafusion/case_id_deliverables.yaml
@@ -13,12 +13,6 @@ files:
   tag: fusioncatcher-summary
 - format: tsv
   id: solidfawn
-  path: /path/to/rnafusion/cases/case_id/pizzly/solidfawn.pizzly.txt
-  path_index: ~
-  step: pizzly
-  tag: pizzly
-- format: tsv
-  id: solidfawn
   path: /path/to/rnafusion/cases/case_id/starfusion/solidfawn.starfusion.fusion_predictions.tsv
   path_index: ~
   step: star-fusion
@@ -29,12 +23,12 @@ files:
   path_index: ~
   step: arriba
   tag: arriba
-- format: tsv
-  id: solidfawn
-  path: /path/to/rnafusion/cases/case_id/squid/solidfawn.squid.fusions.annotated.txt
+- format: cram
+  id: CASEID
+  path: /path/to/rnafusion/cases/case_id/cram_starfusion/solidfawn.cram
   path_index: ~
-  step: squid
-  tag: squid
+  step: star-fusion
+  tag: star-fusion-cram
 - format: html
   id: solidfawn
   path: /path/to/rnafusion/cases/case_id/fusionreport/case_id/index.html

--- a/tests/fixtures/rnafusion/case_id_deliverables.yaml
+++ b/tests/fixtures/rnafusion/case_id_deliverables.yaml
@@ -24,7 +24,7 @@ files:
   step: arriba
   tag: arriba
 - format: cram
-  id: CASEID
+  id: solidfawn
   path: /path/to/rnafusion/cases/case_id/cram_starfusion/solidfawn.cram
   path_index: ~
   step: star-fusion


### PR DESCRIPTION
## Description

- Updates rnafusion tags: adds cram and removes pizzly and squid

### How to prepare for test
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b rnafusion_tags`

### How to test
- 

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
