### PR TITLE
add metrics files for rnafusion

### DIFF
--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -59,6 +59,16 @@ RNAFUSION_COMMON_TAGS = {
         "tags": ["cram"],
         "used_by": ["deliver"],
     },
+    frozenset({"multiqc-json"}): {
+        "is_mandatory": True,
+        "tags": ["multiqc-json"],
+        "used_by": ["deliver"],
+    },
+    frozenset({"qc-metrics"}): {
+        "is_mandatory": True,
+        "tags": ["qc-metrics"],
+        "used_by": ["cg"],
+    },
 }
 
 NXF_RNAFUSION_COMMON_TAGS = {**RNAFUSION_COMMON_TAGS, **NEXTFLOW_COMMON_TAGS}

--- a/docs/rnafusion_map.md
+++ b/docs/rnafusion_map.md
@@ -12,3 +12,5 @@
 | multiqc-html, report                                           | True        | multiqc-html, rna                           | deliver, scout        |  
 | samplesheet-valid                                              | True        | samplesheet-valid                           | cg               |  
 | software-versions                                              | True        | software-versions                           | cg               |  
+| qc-metrics                                              | True        | qc-metrics                           | cg               |  
+| multiqc-json                                              | True        | multiqc-json                           | deliver               |  

--- a/tests/fixtures/rnafusion/case_id_deliverables.yaml
+++ b/tests/fixtures/rnafusion/case_id_deliverables.yaml
@@ -71,3 +71,15 @@ files:
   path_index: ~
   step: software-versions
   tag: software-versions
+- format: json
+  id: solidfawn
+  path: /path/to/rnafusion/cases/case_id/multiqc/multiqc_data/multiqc_data.json
+  path_index: ~
+  step: multiqc-json
+  tag: multiqc-json
+- format: yml
+  id: solidfawn
+  path: /path/to/rnafusion/cases/case_id/solidfawn_metrics_deliverables.yaml
+  path_index: ~
+  step: qc-metrics
+  tag: qc-metrics


### PR DESCRIPTION
## Description
- Adds metrics-qc and multiqc-json tags for rnafusion

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b add_metrics_to_deliverables`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
