### PR TITLE
making fusion files optional for mip-rna

### DIFF
--- a/cg_hermes/config/mip_rna.py
+++ b/cg_hermes/config/mip_rna.py
@@ -73,34 +73,34 @@ MIP_RNA_TAGS = {
     },
     frozenset(["star_fusion"]): {
         "tags": ["fusion", "star-fusion"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset(["arriba_ar"]): {
         "tags": ["fusion", "arriba"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset(["megafusion_ar"]): {
         "tags": ["fusion", "vcf"],
         "index_tags": ["fusion", "vcf-index"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset(["svdb_merge_fusion"]): {
         "tags": ["fusion", "vcf"],
         "index_tags": ["fusion", "vcf-index"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["storage"],
     },
     frozenset(["merge_fusion_reports", "research"]): {
         "tags": ["fusion", "research", "pdf"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["scout"],
     },
     frozenset(["merge_fusion_reports", "clinical"]): {
         "tags": ["fusion", "pdf", "clinical"],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": ["scout"],
     },
     frozenset(["build_sj_tracks", "coverage"]): {


### PR DESCRIPTION
## Description
THIS PR makes the fusion files generated by MIP-rna an optional output.  

### How to prepare for test
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b no-mip-fusion`

### How to test
- [x] Remove fusion files from `finequagga_deliverables.yaml`
- [x] Do `cg workflow mip-rna store finequagga`
- [x] Do `housekeeper get bundle -v finequagga`

### Expected test outcome
- [x] Check that the files are stored in housekeeper.
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] Tests executed by AJ
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
