### PR TITLE
add nextclade ks-delivery tag

### DIFF
--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -82,7 +82,7 @@ MUTANT_COMMON_TAGS = {
     },
     frozenset({"nextclade-summary", "report"}): {
         "is_mandatory": True,
-        "tags": ["typing-summary", "nextclade"],
+        "tags": ["ks-delivery", "typing-summary", "nextclade"],
         "used_by": ["deliver"],
     },
     frozenset({"ks-results", "report"}): {

--- a/docs/mutant_map.md
+++ b/docs/mutant_map.md
@@ -16,7 +16,7 @@
 | vcf-covid, variant-calling            | False     | tsv, vcf-report                                                | deliver          |
 | metrics, result_aggregation           | False     | metrics                                                        | vogue            |
 | multiqc-json, report                  | True      | multiqc-json                                                   | vogue            |
-| nextclade-summary, report             | True      | typing-summary, nextclade                                      | deliver          |
+| nextclade-summary, report             | True      | ks-delivery, typing-summary, nextclade                         | deliver          |
 | ks-results, report                    | True      | ks-delivery, ks-results, typing-report, visualization, csv     | deliver          |
 | ks-aux-results, report                | True      | ks-delivery, ks-aux-results, typing-report, visualization, csv | deliver          |
 | consensus, analysis                   | True      | ks-delivery, fastq, consensus                                  | deliver, storage |


### PR DESCRIPTION
## Description
* This PR adds `ks-delivery` tag to mutant nextclade output for delivery to KS

### How to prepare for test
- [x] ssh to hasta.scilifelab.se
- [x] Use stage: `us`
- [x] Paxa the environment: `paxa`
- [x] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b [THIS-BRANCH-NAME]`
` bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t cg -b master -a`
- [x] deploy MUTANT branch nextclade_summaryfile with changes to gms-artic and updated singularity images

### How to test
- [x] cg workflow mutant start maturejay
- [x] cg deliver analysis -d sars-cov-2 -t 381752

### Expected test outcome
- [x] Check that nextclade summary has tag ks_delivery in houskeeper
- [x] nextclade summary is delivered to customer inbox on hasta
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [x] Tests executed by talnor
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
