### PR TITLE
Remove Vogue, add Janus

### DIFF
--- a/cg_hermes/config/balsamic.py
+++ b/cg_hermes/config/balsamic.py
@@ -241,7 +241,7 @@ QC_TAGS = {
     frozenset(RAW_TAGS["metrics_deliverables.yaml"]): {  # QC metrics
         "tags": ["qc-metrics"],
         "is_mandatory": True,
-        "used_by": ["audit", "cg", "vogue"],
+        "used_by": ["audit", "cg"],
     },
 }
 

--- a/cg_hermes/config/microsalt.py
+++ b/cg_hermes/config/microsalt.py
@@ -18,7 +18,7 @@ MICROSALT_COMMON_TAGS = {
     frozenset({"microsalt-json", "result_aggregation"}): {
         "is_mandatory": False,
         "tags": ["typing-report", "qc-metrics"],
-        "used_by": ["vogue"],
+        "used_by": ["storage"],
     },
     frozenset({"runtime-settings", "analysis"}): {
         "is_mandatory": True,

--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -162,7 +162,7 @@ MIP_DNA_TAGS = {
     frozenset(["multiqc_ar", "json"]): {
         "tags": ["multiqc-json"],
         "is_mandatory": True,
-        "used_by": ["vogue"],
+        "used_by": ["storage"],
     },
     frozenset(["mitodel"]): {
         "tags": ["mitodel"],

--- a/cg_hermes/config/mip_rna.py
+++ b/cg_hermes/config/mip_rna.py
@@ -44,7 +44,7 @@ MIP_RNA_TAGS = {
     frozenset(["multiqc_ar", "json"]): {
         "tags": ["multiqc-json"],
         "is_mandatory": True,
-        "used_by": ["vogue"],
+        "used_by": ["storage"],
     },
     frozenset(["qccollect_ar", "deliverable"]): {
         "tags": ["qc-metrics", "deliverable"],

--- a/cg_hermes/config/mutant.py
+++ b/cg_hermes/config/mutant.py
@@ -73,12 +73,12 @@ MUTANT_COMMON_TAGS = {
     frozenset({"metrics", "result_aggregation"}): {
         "is_mandatory": False,
         "tags": ["metrics"],
-        "used_by": ["vogue"],
+        "used_by": ["storage"],
     },
     frozenset({"multiqc-json", "report"}): {
         "is_mandatory": True,
         "tags": ["multiqc-json"],
-        "used_by": ["vogue"],
+        "used_by": ["storage"],
     },
     frozenset({"nextclade-summary", "report"}): {
         "is_mandatory": True,

--- a/cg_hermes/config/tags.py
+++ b/cg_hermes/config/tags.py
@@ -260,7 +260,7 @@ AVAILABLE_USAGES = {
     "nipt",
     "scout",
     "storage",
-    "vogue",
+    "janus",
 }
 
 COMMON_TAG_CATEGORIES = {

--- a/docs/balsamic_map.md
+++ b/docs/balsamic_map.md
@@ -1,75 +1,75 @@
-| Balsamic tags                                                  | Mandatory   | HK tags                                   | Used by               |
-|----------------------------------------------------------------|-------------|-------------------------------------------|-----------------------|
-| balsamic-config                                                | True        | balsamic-config                           | audit, cg             |
-| balsamic-report                                                | True        | balsamic-report                           | audit                 |
-| balsamic-dag                                                   | True        | balsamic-dag                              | audit                 |
-| html, multiqc-html                                             | True        | multiqc-html                              | audit, deliver, scout |
-| multiqc-json, json                                             | True        | multiqc-json                              | audit                 |
-| yaml, qc-metrics-yaml                                          | True        | qc-metrics                                | audit, cg, vogue      |
-| tumor-cram, cram                                               | True        | tumor, cram                               | deliver, scout        |
-| cram, tumor-cram-index                                         | True        | tumor, cram-index                         | deliver, scout        |
-| cram, normal-cram                                              | False       | normal, cram                              | deliver, scout        |
-| cram, normal-cram-index                                        | False       | normal, cram-index                        | deliver, scout        |
-| vcf-tumor, germline-vcf-tumor, dnascope, snv                   | True        | germline, vcf-snv-germline-tumor          | deliver               |
-| vcf-tumor, germline-vcf-tumor-index, dnascope, snv             | True        | germline, vcf-snv-germline-tumor-index    | deliver               |
-| vcf-normal, germline-vcf-normal, dnascope, snv                 | False       | germline, vcf-snv-germline-normal         | deliver               |
-| vcf-normal, snv, dnascope, germline-vcf-normal-index           | False       | germline, vcf-snv-germline-normal-index   | deliver               |
-| genotype-vcf-dnascope, vcf-dnascope                            | False       | dnascope, normal, vcf                     | cg, genotype          |
-| genotype-vcf-dnascope-index, vcf-dnascope                      | False       | dnascope, normal, vcf-index               | cg, genotype          |
-| vcf-tumor, manta-germline, sv, germline-vcf-tumor              | True        | germline, vcf-sv-germline-tumor           | deliver               |
-| vcf-tumor, manta-germline, germline-vcf-tumor-index, sv        | True        | germline, vcf-sv-germline-tumor-index     | deliver               |
-| vcf-normal, manta-germline, sv, germline-vcf-normal            | False       | germline, vcf-sv-germline-normal          | deliver               |
-| vcf-normal, manta-germline, sv, germline-vcf-normal-index      | False       | germline, vcf-sv-germline-normal-index    | deliver               |
-| research-vcf-svdb, vcf-svdb                                    | True        | svdb, vcf-sv                              | deliver               |
-| research-vcf-svdb-index, vcf-svdb                              | True        | svdb, vcf-sv-index                        | deliver               |
-| vcf-pass-svdb, research-vcf-pass-svdb                          | True        | svdb, vcf-sv-research                     | deliver               |
-| vcf-pass-svdb, research-vcf-pass-svdb-index                    | True        | svdb, vcf-sv-research-index               | deliver               |
-| clinical-vcf-pass-svdb, vcf-pass-svdb                          | True        | svdb, vcf-sv-clinical                     | deliver, scout        |
-| clinical-vcf-pass-svdb-index, vcf-pass-svdb                    | True        | svdb, vcf-sv-clinical-index               | deliver, scout        |
-| vcf-tnscope, research-vcf-tnscope                              | False       | tnscope, vcf-snv                          | deliver               |
-| vcf-tnscope, research-vcf-tnscope-index                        | False       | tnscope, vcf-snv-index                    | deliver               |
-| vcf-pass-tnscope, research-vcf-pass-tnscope, snv               | False       | tnscope, vcf-snv-research                 | deliver               |
-| vcf-pass-tnscope, research-vcf-pass-tnscope-index, snv         | False       | tnscope, vcf-snv-research-index           | deliver               |
-| vcf-pass-tnscope, snv, clinical-vcf-pass-tnscope               | False       | tnscope, vcf-snv-clinical                 | deliver, scout        |
-| vcf-pass-tnscope, clinical-vcf-pass-tnscope-index, snv         | False       | tnscope, vcf-snv-clinical-index           | deliver, scout        |
-| clinical-ascat-copynumber, ascat-copynumber                    | False       | ascatngs, metrics                         | deliver               |
-| rd-delly, clinical-rd-delly                                    | True        | delly, coverage                           | deliver               |
-| cnv-somatic-cgh-tumor, cgh-tumor                               | False       | cnvkit, tumor, vcf2cytosure               | deliver, scout        |
-| cgh-normal, cnv-somatic-cgh-normal                             | False       | tiddit, normal, vcf2cytosure              | deliver, scout        |
-| gens-bed, cov, cnv-gens-bed                                    | False       | gens, coverage, bed                       | scout                 |
-| gens-bed, cov, cnv-gens-bed-index                              | False       | gens, coverage, bed-index                 | scout                 |
-| gens-bed, cnv-gens-bed, baf                                    | False       | gens, fracsnp, bed                        | scout                 |
-| gens-bed, cnv-gens-bed-index, baf                              | False       | gens, fracsnp, bed-index                  | scout                 |
-| research-vcf-vardict, vcf-vardict                              | False       | vardict, vcf-snv                          | deliver               |
-| vcf-vardict, research-vcf-vardict-index                        | False       | vardict, vcf-snv-index                    | deliver               |
-| vcf-pass-vardict, research-vcf-pass-vardict, snv               | False       | vardict, vcf-snv-research                 | deliver               |
-| vcf-pass-vardict, research-vcf-pass-vardict-index, snv         | False       | vardict, vcf-snv-research-index           | deliver               |
-| vcf-pass-vardict, clinical-vcf-pass-vardict, snv               | False       | vardict, vcf-snv-clinical                 | deliver, scout        |
-| vcf-pass-vardict, clinical-vcf-pass-vardict-index, snv         | False       | vardict, vcf-snv-clinical-index           | deliver, scout        |
-| cns, cnv-cns                                                   | False       | cnvkit, metrics, segments                 | deliver               |
-| cnv-cnr, cnr                                                   | False       | cnvkit, regions                           | storage               |
-| cnv-gene-metrics, gene-metrics                                 | False       | cnvkit, metrics, genes                    | deliver               |
-| clinical-cnv-report-pdf, cnv-report-pdf                        | True        | cnv-report                                | deliver, scout        |
-| circular-cnvpytor, clinical-circular-cnvpytor                  | False       | circular-plot, cnvpytor, visualization    | storage               |
-| scatter-cnvpytor, clinical-scatter-cnvpytor                    | False       | scatter-plot, cnvpytor, visualization     | storage               |
-| clinical-plot-ascat-profile, plot-ascat-profile                | False       | profile-plot, ascatngs, visualization     | storage               |
-| clinical-plot-raw-profile, plot-raw-profile                    | False       | raw-profile-plot, ascatngs, visualization | storage               |
-| clinical-plot-aspcf, plot-aspcf                                | False       | aspcf-plot, ascatngs, visualization       | storage               |
-| plot-tumor, clinical-plot-tumor                                | False       | tumor-plot, ascatngs, visualization       | storage               |
-| plot-germline, clinical-plot-germline                          | False       | germline-plot, ascatngs, visualization    | storage               |
-| clinical-plot-sunrise, plot-sunrise                            | False       | sunrise-plot, ascatngs, visualization     | storage               |
-| cov-tumor-tiddit, clinical-cov-tumor-tiddit                    | False       | tiddit, tumor, coverage                   | deliver               |
-| cov-normal-tiddit, clinical-cov-normal-tiddit                  | False       | tiddit, normal, coverage                  | deliver               |
-| tmb, vardict, research-tmb, snv                                | False       | research, vardict, tmb                    | storage               |
-| tmb, tnscope, research-tmb, snv                                | False       | research, tnscope, tmb                    | storage               |
-| cram, umi-tumor-cram                                           | True        | umi-cram, tumor                           | deliver, scout        |
-| cram, umi-tumor-cram-index                                     | True        | umi-cram-index, tumor                     | deliver, scout        |
-| cram, umi-normal-cram                                          | False       | umi-cram, normal                          | deliver, scout        |
-| cram, umi-normal-cram-index                                    | False       | umi-cram-index, normal                    | deliver, scout        |
-| vcf-tnscope-umi, research-vcf-tnscope-umi                      | True        | tnscope-umi, vcf-umi-snv                  | deliver               |
-| vcf-tnscope-umi, research-vcf-tnscope-umi-index                | True        | tnscope-umi, vcf-umi-snv-index            | deliver               |
-| research-vcf-pass-tnscope-umi, vcf-pass-tnscope-umi, snv       | True        | tnscope-umi, vcf-umi-snv-research         | deliver               |
-| vcf-pass-tnscope-umi, research-vcf-pass-tnscope-umi-index, snv | True        | tnscope-umi, vcf-umi-snv-research-index   | deliver               |
-| vcf-pass-tnscope-umi, clinical-vcf-pass-tnscope-umi, snv       | True        | tnscope-umi, vcf-umi-snv-clinical         | deliver, scout        |
-| vcf-pass-tnscope-umi, clinical-vcf-pass-tnscope-umi-index, snv | True        | tnscope-umi, vcf-umi-snv-clinical-index   | deliver, scout        |
-| tnscope-umi, tmb, research-tmb, snv                            | True        | research, tnscope-umi, tmb                | storage               |
+| Balsamic tags                                                  | Mandatory | HK tags                                   | Used by               |
+|----------------------------------------------------------------|-----------|-------------------------------------------|-----------------------|
+| balsamic-config                                                | True      | balsamic-config                           | audit, cg             |
+| balsamic-report                                                | True      | balsamic-report                           | audit                 |
+| balsamic-dag                                                   | True      | balsamic-dag                              | audit                 |
+| html, multiqc-html                                             | True      | multiqc-html                              | audit, deliver, scout |
+| json, multiqc-json                                             | True      | multiqc-json                              | audit                 |
+| yaml, qc-metrics-yaml                                          | True      | qc-metrics                                | audit, cg             |
+| tumor-cram, cram                                               | True      | tumor, cram                               | deliver, scout        |
+| cram, tumor-cram-index                                         | True      | tumor, cram-index                         | deliver, scout        |
+| cram, normal-cram                                              | False     | normal, cram                              | deliver, scout        |
+| cram, normal-cram-index                                        | False     | normal, cram-index                        | deliver, scout        |
+| dnascope, germline-vcf-tumor, vcf-tumor, snv                   | True      | germline, vcf-snv-germline-tumor          | deliver               |
+| dnascope, germline-vcf-tumor-index, vcf-tumor, snv             | True      | germline, vcf-snv-germline-tumor-index    | deliver               |
+| dnascope, germline-vcf-normal, vcf-normal, snv                 | False     | germline, vcf-snv-germline-normal         | deliver               |
+| dnascope, germline-vcf-normal-index, vcf-normal, snv           | False     | germline, vcf-snv-germline-normal-index   | deliver               |
+| vcf-dnascope, genotype-vcf-dnascope                            | False     | dnascope, normal, vcf                     | cg, genotype          |
+| vcf-dnascope, genotype-vcf-dnascope-index                      | False     | dnascope, normal, vcf-index               | cg, genotype          |
+| sv, germline-vcf-tumor, manta-germline, vcf-tumor              | True      | germline, vcf-sv-germline-tumor           | deliver               |
+| manta-germline, sv, germline-vcf-tumor-index, vcf-tumor        | True      | germline, vcf-sv-germline-tumor-index     | deliver               |
+| vcf-normal, germline-vcf-normal, sv, manta-germline            | False     | germline, vcf-sv-germline-normal          | deliver               |
+| germline-vcf-normal-index, manta-germline, sv, vcf-normal      | False     | germline, vcf-sv-germline-normal-index    | deliver               |
+| vcf-svdb, research-vcf-svdb                                    | True      | svdb, vcf-sv                              | deliver               |
+| vcf-svdb, research-vcf-svdb-index                              | True      | svdb, vcf-sv-index                        | deliver               |
+| vcf-pass-svdb, research-vcf-pass-svdb                          | True      | svdb, vcf-sv-research                     | deliver               |
+| research-vcf-pass-svdb-index, vcf-pass-svdb                    | True      | svdb, vcf-sv-research-index               | deliver               |
+| vcf-pass-svdb, clinical-vcf-pass-svdb                          | True      | svdb, vcf-sv-clinical                     | deliver, scout        |
+| vcf-pass-svdb, clinical-vcf-pass-svdb-index                    | True      | svdb, vcf-sv-clinical-index               | deliver, scout        |
+| research-vcf-tnscope, vcf-tnscope                              | False     | tnscope, vcf-snv                          | deliver               |
+| research-vcf-tnscope-index, vcf-tnscope                        | False     | tnscope, vcf-snv-index                    | deliver               |
+| vcf-pass-tnscope, research-vcf-pass-tnscope, snv               | False     | tnscope, vcf-snv-research                 | deliver               |
+| research-vcf-pass-tnscope-index, vcf-pass-tnscope, snv         | False     | tnscope, vcf-snv-research-index           | deliver               |
+| clinical-vcf-pass-tnscope, vcf-pass-tnscope, snv               | False     | tnscope, vcf-snv-clinical                 | deliver, scout        |
+| clinical-vcf-pass-tnscope-index, vcf-pass-tnscope, snv         | False     | tnscope, vcf-snv-clinical-index           | deliver, scout        |
+| ascat-copynumber, clinical-ascat-copynumber                    | False     | ascatngs, metrics                         | deliver               |
+| rd-delly, clinical-rd-delly                                    | True      | delly, coverage                           | deliver               |
+| cnv-somatic-cgh-tumor, cgh-tumor                               | False     | cnvkit, tumor, vcf2cytosure               | deliver, scout        |
+| cnv-somatic-cgh-normal, cgh-normal                             | False     | tiddit, normal, vcf2cytosure              | deliver, scout        |
+| cov, cnv-gens-bed, gens-bed                                    | False     | gens, coverage, bed                       | scout                 |
+| cnv-gens-bed-index, cov, gens-bed                              | False     | gens, coverage, bed-index                 | scout                 |
+| baf, cnv-gens-bed, gens-bed                                    | False     | gens, fracsnp, bed                        | scout                 |
+| cnv-gens-bed-index, baf, gens-bed                              | False     | gens, fracsnp, bed-index                  | scout                 |
+| research-vcf-vardict, vcf-vardict                              | False     | vardict, vcf-snv                          | deliver               |
+| vcf-vardict, research-vcf-vardict-index                        | False     | vardict, vcf-snv-index                    | deliver               |
+| vcf-pass-vardict, research-vcf-pass-vardict, snv               | False     | vardict, vcf-snv-research                 | deliver               |
+| vcf-pass-vardict, research-vcf-pass-vardict-index, snv         | False     | vardict, vcf-snv-research-index           | deliver               |
+| vcf-pass-vardict, clinical-vcf-pass-vardict, snv               | False     | vardict, vcf-snv-clinical                 | deliver, scout        |
+| vcf-pass-vardict, clinical-vcf-pass-vardict-index, snv         | False     | vardict, vcf-snv-clinical-index           | deliver, scout        |
+| cnv-cns, cns                                                   | False     | cnvkit, metrics, segments                 | deliver               |
+| cnr, cnv-cnr                                                   | False     | cnvkit, regions                           | storage               |
+| cnv-gene-metrics, gene-metrics                                 | False     | cnvkit, metrics, genes                    | deliver               |
+| clinical-cnv-report-pdf, cnv-report-pdf                        | True      | cnv-report                                | deliver, scout        |
+| circular-cnvpytor, clinical-circular-cnvpytor                  | False     | circular-plot, cnvpytor, visualization    | storage               |
+| clinical-scatter-cnvpytor, scatter-cnvpytor                    | False     | scatter-plot, cnvpytor, visualization     | storage               |
+| plot-ascat-profile, clinical-plot-ascat-profile                | False     | profile-plot, ascatngs, visualization     | storage               |
+| clinical-plot-raw-profile, plot-raw-profile                    | False     | raw-profile-plot, ascatngs, visualization | storage               |
+| plot-aspcf, clinical-plot-aspcf                                | False     | aspcf-plot, ascatngs, visualization       | storage               |
+| plot-tumor, clinical-plot-tumor                                | False     | tumor-plot, ascatngs, visualization       | storage               |
+| plot-germline, clinical-plot-germline                          | False     | germline-plot, ascatngs, visualization    | storage               |
+| plot-sunrise, clinical-plot-sunrise                            | False     | sunrise-plot, ascatngs, visualization     | storage               |
+| cov-tumor-tiddit, clinical-cov-tumor-tiddit                    | False     | tiddit, tumor, coverage                   | deliver               |
+| clinical-cov-normal-tiddit, cov-normal-tiddit                  | False     | tiddit, normal, coverage                  | deliver               |
+| vardict, research-tmb, tmb, snv                                | False     | research, vardict, tmb                    | storage               |
+| tmb, tnscope, research-tmb, snv                                | False     | research, tnscope, tmb                    | storage               |
+| umi-tumor-cram, cram                                           | True      | umi-cram, tumor                           | deliver, scout        |
+| cram, umi-tumor-cram-index                                     | True      | umi-cram-index, tumor                     | deliver, scout        |
+| umi-normal-cram, cram                                          | False     | umi-cram, normal                          | deliver, scout        |
+| cram, umi-normal-cram-index                                    | False     | umi-cram-index, normal                    | deliver, scout        |
+| research-vcf-tnscope-umi, vcf-tnscope-umi                      | True      | tnscope-umi, vcf-umi-snv                  | deliver               |
+| research-vcf-tnscope-umi-index, vcf-tnscope-umi                | True      | tnscope-umi, vcf-umi-snv-index            | deliver               |
+| research-vcf-pass-tnscope-umi, vcf-pass-tnscope-umi, snv       | True      | tnscope-umi, vcf-umi-snv-research         | deliver               |
+| research-vcf-pass-tnscope-umi-index, vcf-pass-tnscope-umi, snv | True      | tnscope-umi, vcf-umi-snv-research-index   | deliver               |
+| vcf-pass-tnscope-umi, clinical-vcf-pass-tnscope-umi, snv       | True      | tnscope-umi, vcf-umi-snv-clinical         | deliver, scout        |
+| vcf-pass-tnscope-umi, clinical-vcf-pass-tnscope-umi-index, snv | True      | tnscope-umi, vcf-umi-snv-clinical-index   | deliver, scout        |
+| tmb, tnscope-umi, research-tmb, snv                            | True      | research, tnscope-umi, tmb                | storage               |

--- a/docs/microsalt_map.md
+++ b/docs/microsalt_map.md
@@ -1,15 +1,15 @@
-| Microsalt tags                        | Mandatory   | HK tags                      | Used by        |
-|---------------------------------------|-------------|------------------------------|----------------|
-| analysis, sampleinfo                  | True        | config                       | storage, audit |
-| microsalt-qc, result_aggregation      | True        | qc-report, visualization     | deliver        |
-| microsalt-type, result_aggregation    | True        | typing-report, visualization | deliver        |
-| microsalt-json, result_aggregation    | False       | typing-report, qc-metrics    | vogue          |
-| runtime-settings, analysis            | True        | microsalt-config             | storage, audit |
-| assembly                              | True        | assembly                     | storage        |
-| concatination, trimmed-forward-reads  | False       | fastq, forward-strand        | storage        |
-| concatination, trimmed-reverse-reads  | False       | fastq, reverse-strand        | storage        |
-| concatination, trimmed-unpaired-reads | False       | fastq, unpaired-reads        | storage        |
-| analysis, logfile                     | True        | microsalt-log                | audit          |
-| assembly, quast-results               | False       | qc-metrics, assembly         | audit          |
-| reference-alignment-sorted, alignment | True        | bam                          | storage        |
-| insertsize_calc, picard-insertsize    | False       | qc-metrics, picard           | audit          |
+| Microsalt tags                        | Mandatory | HK tags                      | Used by        |
+|---------------------------------------|-----------|------------------------------|----------------|
+| sampleinfo, analysis                  | True      | config                       | storage, audit |
+| microsalt-qc, result_aggregation      | True      | qc-report, visualization     | deliver        |
+| result_aggregation, microsalt-type    | False     | typing-report, visualization | deliver        |
+| microsalt-json, result_aggregation    | False     | typing-report, qc-metrics    | storage        |
+| analysis, runtime-settings            | True      | microsalt-config             | storage, audit |
+| assembly                              | False     | assembly                     | storage        |
+| trimmed-forward-reads, concatination  | False     | fastq, forward-strand        | storage        |
+| concatination, trimmed-reverse-reads  | False     | fastq, reverse-strand        | storage        |
+| concatination, trimmed-unpaired-reads | False     | fastq, unpaired-reads        | storage        |
+| analysis, logfile                     | False     | microsalt-log                | audit          |
+| assembly, quast-results               | False     | qc-metrics, assembly         | audit          |
+| alignment, reference-alignment-sorted | False     | bam                          | storage        |
+| insertsize_calc, picard-insertsize    | False     | qc-metrics, picard           | audit          |

--- a/docs/mip-dna_map.md
+++ b/docs/mip-dna_map.md
@@ -1,49 +1,51 @@
 | Mip-dna tags                        | Mandatory | HK tags                          | Used by      |
-| ----------------------------------- | --------- | -------------------------------- | ------------ |
+|-------------------------------------|-----------|----------------------------------|--------------|
 | chanjo_sexcheck                     | False     | chanjo, sex-check                | scout        |
-| chromograph_cov, tcov               | False     | chromograph, tcov                | scout        |
+| sites, chromograph_upd              | False     | chromograph, upd, sites          | scout        |
+| regions, chromograph_upd            | False     | chromograph, upd, regions        | scout        |
+| tcov, chromograph_cov               | False     | chromograph, tcov                | scout        |
+| autozyg, chromograph_rhoviz         | False     | chromograph, autozyg             | scout        |
+| fracsnp, chromograph_rhoviz         | False     | chromograph, fracsnp             | scout        |
 | clinical, endvariantannotationblock | True      | vcf-snv-clinical                 | scout        |
-| clinical, me_filter                 | False     | clinical, mobile-elements, vcf   | scout        |
-| clinical, sv_reformat               | False     | vcf-sv-clinical                  | scout        |
-| config, mip_analyse                 | True      | mip-analyse, config              | cg, audit    |
-| config_analysis, mip_analyse        | True      | mip-config                       | cg, audit    |
-| coverage, sambamba_depth            | True      | coverage, sambamba-depth         | chanjo       |
-| expansionhunter, str_alignments     | False     | expansionhunter, bam             | scout        |
-| expansionhunter, str_variants       | False     | expansionhunter, vcf-str         | scout        |
-| expansionhunter, variant_catalog    | False     | expansionhunter, variant-catalog | scout        |
-| gatk_baserecalibration              | False     | cram                             | scout        |
-| gatk_combinevariantcallsets         | True      | snv-gbcf, snv-bcf                | genotype     |
-| gens_generatedata, baf              | False     | gens, fracsnp                    | scout        |
-| gens_generatedata, cov              | False     | gens, coverage                   | scout        |
+| research, endvariantannotationblock | True      | vcf-snv-research                 | scout        |
+| sv_str, expansionhunter             | False     | vcf-str                          | scout        |
+| str_variants, expansionhunter       | False     | expansionhunter, vcf-str         | scout        |
+| str_alignment, expansionhunter      | False     | expansionhunter, bam             | scout        |
+| variant_catalog, expansionhunter    | False     | expansionhunter, variant-catalog | scout        |
 | glnexus_merge                       | False     | deepvariant, snv, vcf            | storage      |
-| html, multiqc_ar                    | True      | multiqc-html                     | scout        |
-| json, multiqc_ar                    | True      | multiqc-json                     | vogue        |
-| log, mip_analyse                    | True      | mip-log                          | audit        |
+| markduplicates                      | False     | cram                             | scout        |
+| gatk_combinevariantcallsets         | True      | snv-gbcf, snv-bcf                | genotype     |
+| gens_generatedata, baf              | False     | gens, fracsnp, bed               | scout        |
+| gens_generatedata, cov              | False     | gens, coverage, bed              | scout        |
 | me_merge_vcfs                       | False     | retroseq, vcf                    | audit        |
-| mitodel                             | False     | mitodel                          | scout        |
-| peddy, peddy_ar                     | True      | peddy, ped                       | audit, scout |
-| peddy_ar, ped_check                 | True      | peddy, ped-check                 | audit, scout |
+| clinical, me_filter                 | False     | mobile-elements, clinical, vcf   | scout        |
+| research, me_filter                 | False     | mobile-elements, research, vcf   | scout        |
+| mip_analyse, config                 | True      | mip-analyse, config              | cg, audit    |
+| mip_analyse, config_analysis        | True      | mip-config                       | cg, audit    |
+| mip_analyse, log                    | True      | mip-log                          | audit        |
 | pedigree, mip_analyse               | True      | pedigree-yaml                    | audit        |
 | pedigree_fam, mip_analyse           | True      | pedigree                         | scout        |
-| qccollect_ar, audit                 | True      | qc-metrics, audit                | audit        |
-| qccollect_ar, deliverable           | True      | qc-metrics, deliverable          | audit        |
-| references_info, mip_analyse        | True      | mip-analyse, reference-info      | audit        |
-| regions, chromograph_upd            | False     | chromograph, upd, regions        | scout        |
-| research, endvariantannotationblock | True      | vcf-snv-research                 | scout        |
-| research, me_filter                 | False     | research, mobile-elements, vcf   | scout        |
-| research, sv_reformat               | False     | vcf-sv-research                  | scout        |
-| rhocall_viz                         | False     | rhocall-viz                      | scout        |
+| mip_analyse, references_info        | True      | mip-analyse, reference-info      | audit        |
 | sample_info, mip_analyse            | True      | sample-info                      | cg, audit    |
+| html, multiqc_ar                    | True      | multiqc-html                     | scout        |
+| json, multiqc_ar                    | True      | multiqc-json                     | storage      |
+| mitodel                             | False     | mitodel                          | scout        |
+| peddy_ar, ped_check                 | True      | peddy, ped-check                 | audit, scout |
+| peddy_ar, peddy                     | True      | peddy, ped                       | audit, scout |
+| peddy_ar, sex_check                 | True      | peddy, sex-check                 | audit, scout |
+| qccollect_ar, deliverable           | True      | qc-metrics, deliverable          | audit        |
+| qccollect_ar, audit                 | True      | qc-metrics, audit                | audit        |
+| rhocall_viz                         | False     | rhocall-viz                      | scout        |
+| sambamba_depth, coverage            | True      | coverage, sambamba-depth         | chanjo       |
 | samtools_subsample_mt               | False     | bam-mt                           | scout        |
-| sex_check, peddy_ar                 | True      | peddy, sex-check                 | audit, scout |
-| sites, chromograph_upd              | False     | chromograph, upd, sites          | scout        |
-| sites, upd_ar                       | False     | upd, sites                       | scout        |
 | smncopynumbercaller                 | False     | smn-calling                      | scout        |
 | star_caller                         | False     | cyrius                           | scout        |
 | sv_combinevariantcallsets           | True      | sv-bcf                           | audit        |
-| sv_str, expansionhunter             | False     | vcf-str                          | scout        |
+| sv_reformat, clinical               | False     | vcf-sv-clinical                  | scout        |
+| sv_reformat, research               | False     | vcf-sv-research                  | scout        |
 | telomerecat_ar                      | False     | telomere-calling                 | scout        |
 | tiddit_coverage                     | False     | tiddit-coverage, bigwig          | scout        |
-| upd_ar, regions                     | False     | upd, regions                     | scout        |
-| vcf2cytosure_ar                     | False     | vcf2cytosure                     | scout        |
+| regions, upd_ar                     | False     | upd, regions                     | scout        |
+| sites, upd_ar                       | False     | upd, sites                       | scout        |
 | version_collect_ar                  | True      | exe-ver                          | audit        |
+| vcf2cytosure_ar                     | False     | vcf2cytosure                     | scout        |

--- a/docs/mip-rna_map.md
+++ b/docs/mip-rna_map.md
@@ -1,29 +1,30 @@
-| Mip-rna tags                            | Mandatory   | HK tags                     | Used by      |
-|-------------------------------------|-------------|-----------------------------|--------------|
-| arriba_ar                           | True        | fusion, arriba              | storage      |
-| blobfish                            | False       | deseq2                      | storage      |
-| build_sj_tracks, coverage           | True        | bigwig, coverage            | scout        |
-| build_sj_tracks, junction           | True        | bed, junction               | scout        |
-| config, mip_analyse                 | True        | mip-analyse, config         | cg, audit    |
-| config_analysis, mip_analyse        | True        | mip-config                  | cg, audit    |
-| gatk_asereadcounter                 | True        | asereadcounter              | storage      |
-| html, multiqc_ar                    | True        | multiqc-html                | scout        |
-| json, multiqc_ar                    | True        | multiqc-json                | vogue        |
-| log, mip_analyse                    | True        | mip-log                     | audit        |
-| markduplicates                      | True        | cram                        | storage      |
-| megafusion_ar                       | True        | fusion, vcf                 | storage      |
-| merege_fusion_reports, clinical     | True        | fusion, pdf, clinical       | scout        |
-| merege_fusion_reports, research     | True        | fusion, pdf, research       | scout        |
-| pedigree, mip_analyse               | True        | pedigree-yaml               | audit        |
-| pedigree_fam, mip_analyse           | True        | pedigree                    | scout        |
-| qccollect_ar, deliverable           | True        | qc-metrics, deliverable    | audit        |
-| qccollect_ar, audit                 | True        | qc-metrics, audit           | audit        |
-| references_info, mip_analyse        | True        | mip-analyse, reference-info | audit        |
-| salmon_quant                        | True        | salmon-quant                | storage      |
-| sample_info, mip_analyse            | True        | sample-info                 | cg, audit    |
-| star_fusion                         | True        | fusion, star-fusion         | storage      |
-| stringtie_ar                        | True        | assembly, stringtie         | storage      |
-| svdb_merge_fusion                   | True        | fusion, vcf                 | storage      |
-| vcfparser_ar, clinical              | True        | vcf-snv-clinical            | storage      |
-| vcfparser_ar, research              | True        | vcf-snv-research            | storage      |
-| version_collect_ar                  | True        | exe-ver                     | audit        |
+| Mip-rna tags                   | Mandatory | HK tags                     | Used by   |
+|--------------------------------|-----------|-----------------------------|-----------|
+| mip_analyse, config            | True      | mip-analyse, config         | cg, audit |
+| mip_analyse, config_analysis   | True      | mip-config                  | cg, audit |
+| mip_analyse, log               | True      | mip-log                     | audit     |
+| mip_analyse, pedigree          | True      | pedigree-yaml               | audit     |
+| mip_analyse, references_info   | True      | mip-analyse, reference-info | audit     |
+| mip_analyse, sample_info       | True      | sample-info                 | cg, audit |
+| mip_analyse, pedigree_fam      | True      | pedigree                    | storage   |
+| html, multiqc_ar               | True      | multiqc-html                | audit     |
+| json, multiqc_ar               | True      | multiqc-json                | storage   |
+| deliverable, qccollect_ar      | True      | qc-metrics, deliverable     | audit     |
+| qccollect_ar, audit            | True      | qc-metrics, audit           | audit     |
+| version_collect_ar             | True      | exe-ver                     | audit     |
+| salmon_quant                   | True      | salmon-quant                | storage   |
+| blobfish                       | False     | deseq2                      | storage   |
+| star_fusion                    | False     | fusion, star-fusion         | storage   |
+| arriba_ar                      | False     | fusion, arriba              | storage   |
+| megafusion_ar                  | False     | fusion, vcf                 | storage   |
+| svdb_merge_fusion              | False     | fusion, vcf                 | storage   |
+| research, merge_fusion_reports | False     | fusion, research, pdf       | scout     |
+| clinical, merge_fusion_reports | False     | fusion, pdf, clinical       | scout     |
+| coverage, build_sj_tracks      | True      | coverage, bigwig            | scout     |
+| junction, build_sj_tracks      | True      | junction, bed               | scout     |
+| markduplicates                 | True      | cram                        | scout     |
+| stringtie_ar                   | False     | stringtie, assembly         | storage   |
+| gffcompare_ar                  | False     | gffcompare                  | storage   |
+| gatk_asereadcounter            | True      | asereadcounter              | storage   |
+| research, vcfparser_ar         | True      | vcf-snv-research            | storage   |
+| vcfparser_ar, clinical         | True      | vcf-snv-clinical            | storage   |

--- a/docs/mutant_map.md
+++ b/docs/mutant_map.md
@@ -1,27 +1,27 @@
-| MUTANT tags                           | Mandatory | HK tags                                                        | Used by          |
+| Mutant tags                           | Mandatory | HK tags                                                        | Used by          |
 |---------------------------------------|-----------|----------------------------------------------------------------|------------------|
 | sampleinfo, runinfo                   | True      | config                                                         | storage, audit   |
-| instrument-properties, report         | False     | fohm-delivery, instrument-properties                           | storage, audit   |
+| report, instrument-properties         | False     | fohm-delivery, instrument-properties                           | storage, audit   |
 | runtime-settings, runinfo             | True      | mutant-config                                                  | storage, audit   |
 | software-versions, runinfo            | True      | software-versions                                              | storage, audit   |
-| runinfo, logfile                      | True      | mutant-log                                                     | audit            |
-| concatination, forward-reads          | True      | fastq, forward-strand                                          | storage          |
+| logfile, runinfo                      | True      | mutant-log                                                     | audit            |
+| forward-reads, concatination          | True      | fastq, forward-strand                                          | storage          |
 | concatination, reverse-reads          | False     | fastq, reverse-strand                                          | storage          |
 | SARS-CoV-2-info, report               | False     | fohm-delivery, komplettering, visualization                    | deliver          |
-| SARS-CoV-2-qc, result_aggregation     | False     | fohm-delivery, pangolin-typing, csv, visualization             | audit            |
-| pangolin-typing, report               | False     | fohm-delivery, pangolin-typing, csv, visualization             | audit            |
-| pangolin-typing-fohm, report          | False     | fohm-delivery, pangolin-typing-fohm, csv                       | deliver          |
-| alignment, reference-alignment-sorted | False     | bam                                                            | storage          |
-| vcf-covid, genotyping                 | False     | vcf, vcf-report, fohm-delivery                                 | deliver          |
-| vcf-covid, variant-calling            | False     | tsv, vcf-report                                                | deliver          |
-| metrics, result_aggregation           | False     | metrics                                                        | vogue            |
-| multiqc-json, report                  | True      | multiqc-json                                                   | vogue            |
+| result_aggregation, SARS-CoV-2-qc     | False     | fohm-delivery, pangolin-typing, csv, visualization             | audit            |
+| pangolin-typing, report               | False     | fohm-delivery, pangolin-typing, visualization, csv             | audit            |
+| report, pangolin-typing-fohm          | False     | fohm-delivery, pangolin-typing-fohm, csv                       | deliver          |
+| reference-alignment-sorted, alignment | False     | bam                                                            | storage          |
+| genotyping, vcf-covid                 | False     | vcf, vcf-report, fohm-delivery                                 | deliver          |
+| variant-calling, vcf-covid            | False     | tsv, vcf-report                                                | deliver          |
+| result_aggregation, metrics           | False     | metrics                                                        | storage          |
+| multiqc-json, report                  | True      | multiqc-json                                                   | storage          |
 | nextclade-summary, report             | True      | ks-delivery, typing-summary, nextclade                         | deliver          |
-| ks-results, report                    | True      | ks-delivery, ks-results, typing-report, visualization, csv     | deliver          |
+| report, ks-results                    | True      | ks-delivery, ks-results, typing-report, visualization, csv     | deliver          |
 | ks-aux-results, report                | True      | ks-delivery, ks-aux-results, typing-report, visualization, csv | deliver          |
 | consensus, analysis                   | True      | ks-delivery, fastq, consensus                                  | deliver, storage |
 | consensus-sample, consensus           | False     | fohm-delivery, fasta, consensus-sample                         | deliver, storage |
-| multiqc-html, report                  | True      | ks-delivery, multiqc-html                                      | deliver          |
+| report, multiqc-html                  | True      | ks-delivery, multiqc-html                                      | deliver          |
 | SARS-CoV-2-sum, report                | False     | artic-sum, csv                                                 | audit            |
 | SARS-CoV-2-var, report                | False     | artic-var, csv                                                 | audit            |
-| SARS-CoV-2-type, typing               | False     | artic-type, csv                                                | audit            |
+| typing, SARS-CoV-2-type               | False     | artic-type, csv                                                | audit            |

--- a/tests/cli/test_export_tags.py
+++ b/tests/cli/test_export_tags.py
@@ -78,3 +78,27 @@ def test_export_rnafusion_tags(cli_runner: CliRunner):
     assert result.exit_code == 0
     # THEN assert that the rnafusion tags was exported
     assert "Rnafusion tags" in result.output
+
+
+def test_export_microsalt_tags(cli_runner: CliRunner):
+    # GIVEN a cli runner
+
+    # WHEN running the export tags command for MicroSALT
+    result = cli_runner.invoke(app, ["--pipeline", "microsalt"])
+
+    # THEN assert that the command exits without problems
+    assert result.exit_code == 0
+    # THEN assert that the MicroSALT tags was exported
+    assert "Microsalt tags" in result.output
+
+
+def test_export_mutant_tags(cli_runner: CliRunner):
+    # GIVEN a cli runner
+
+    # WHEN running the export tags command for Mutant
+    result = cli_runner.invoke(app, ["--pipeline", "mutant"])
+
+    # THEN assert that the command exits without problems
+    assert result.exit_code == 0
+    # THEN assert that the MicroSALT tags was exported
+    assert "Mutant tags" in result.output


### PR DESCRIPTION
## Description

### Added
- `janus` as a valid tag for the used_by field

### Removed
- `vogue` tag

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
