### PR TITLE
(feat taxprofiler): Store multiqc intermediate json files

### DIFF
--- a/cg_hermes/config/taxprofiler.py
+++ b/cg_hermes/config/taxprofiler.py
@@ -67,6 +67,26 @@ TAXPROFILER_COMMON_TAGS = {
         "tags": ["qc-metrics"],
         "used_by": ["cg", "long-term-storage"],
     },
+    frozenset({"multiqc-general-stats", "multiqc"}): {
+        "is_mandatory": True,
+        "tags": ["qc-metrics", "multiqc", "general-stats"],
+        "used_by": ["janus"],
+    },
+    frozenset({"multiqc-fastp", "multiqc"}): {
+        "is_mandatory": True,
+        "tags": ["qc-metrics", "multiqc", "fastp"],
+        "used_by": ["janus"],
+    },
+    frozenset({"multiqc-samtools-stats", "multiqc"}): {
+        "is_mandatory": True,
+        "tags": ["qc-metrics", "multiqc", "samtools-stats"],
+        "used_by": ["janus"],
+    },
+    frozenset({"multiqc-kraken", "multiqc"}): {
+        "is_mandatory": True,
+        "tags": ["qc-metrics", "multiqc", "kraken2"],
+        "used_by": ["janus"],
+    },
 }
 
 TAXPROFILER_TAGS = {**TAXPROFILER_COMMON_TAGS, **NEXTFLOW_TAGS}

--- a/cg_hermes/config/taxprofiler.py
+++ b/cg_hermes/config/taxprofiler.py
@@ -7,6 +7,7 @@ from cg_hermes.constants.tags import (
     ReportTags,
     QCTags,
     BioinfoToolsTags,
+    UsageTags,
 )
 
 TAXPROFILER_COMMON_TAGS = {
@@ -14,85 +15,85 @@ TAXPROFILER_COMMON_TAGS = {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.COMBINED_REPORT],
-        "used_by": ["clinical-delivery", "long-term-storage"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"kraken2_report", "kraken2"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.METAGENOMICS_REPORT],
-        "used_by": ["clinical-delivery", "long-term-storage"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"krona_kraken_plot", "krona"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.KRONA, AnalysisTags.VISUALIZATION],
-        "used_by": ["clinical-delivery", "long-term-storage"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"krona_centrifuge_plot", "krona"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.KRONA, AnalysisTags.VISUALIZATION],
-        "used_by": ["clinical-delivery"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"bracken_combined_report", "bracken"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.BRACKEN, TaxprofilerTags.COMBINED_REPORT],
-        "used_by": ["clinical-delivery"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"bracken_report", "bracken"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.BRACKEN, TaxprofilerTags.METAGENOMICS_REPORT],
-        "used_by": ["clinical-delivery"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"centrifuge_combined_report", "centrifuge"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.CENTRIFUGE, TaxprofilerTags.COMBINED_REPORT],
-        "used_by": ["clinical-delivery"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"centrifuge_report", "centrifuge"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [TaxprofilerTags.CENTRIFUGE, TaxprofilerTags.METAGENOMICS_REPORT],
-        "used_by": ["clinical-delivery"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [ReportTags.MULTIQC_HTML],
-        "used_by": ["clinical-delivery", "long-term-storage"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
         "tags": [ReportTags.MULTIQC_JSON],
-        "used_by": ["clinical-delivery", "long-term-storage"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"qc-metrics"}): {
         "is_mandatory": True,
         "tags": [QCTags.QC_METRICS],
-        "used_by": ["cg", "long-term-storage"],
+        "used_by": [UsageTags.CG, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"multiqc-json", "multiqc-general-stats"}): {
         "is_mandatory": True,
         "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.GENERAL_STATS],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-json", "multiqc-fastp"}): {
         "is_mandatory": True,
         "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, BioinfoToolsTags.FASTP],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-json", "multiqc-samtools-stats"}): {
         "is_mandatory": True,
         "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.SAMTOOLS_STATS],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-json", "multiqc-kraken"}): {
         "is_mandatory": True,
         "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, TaxprofilerTags.KRAKEN2],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
 }
 

--- a/cg_hermes/config/taxprofiler.py
+++ b/cg_hermes/config/taxprofiler.py
@@ -1,90 +1,97 @@
 """Tags that are defined in Taxprofiler deliverables mapped to tags stored in Housekeeper."""
 
 from cg_hermes.config.nextflow import NEXTFLOW_TAGS
+from cg_hermes.constants.tags import (
+    TaxprofilerTags,
+    AnalysisTags,
+    ReportTags,
+    QCTags,
+    BioinfoToolsTags,
+)
 
 TAXPROFILER_COMMON_TAGS = {
     frozenset({"kraken2_combined_report", "kraken2"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["kraken2", "combined-report"],
+        "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.COMBINED_REPORT],
         "used_by": ["clinical-delivery", "long-term-storage"],
     },
     frozenset({"kraken2_report", "kraken2"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["kraken2", "metagenomics-report"],
+        "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.METAGENOMICS_REPORT],
         "used_by": ["clinical-delivery", "long-term-storage"],
     },
     frozenset({"krona_kraken_plot", "krona"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["kraken2", "krona", "visualization"],
+        "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.KRONA, AnalysisTags.VISUALIZATION],
         "used_by": ["clinical-delivery", "long-term-storage"],
     },
     frozenset({"krona_centrifuge_plot", "krona"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["centrifuge", "krona", "visualization"],
+        "tags": [TaxprofilerTags.KRAKEN2, TaxprofilerTags.KRONA, AnalysisTags.VISUALIZATION],
         "used_by": ["clinical-delivery"],
     },
     frozenset({"bracken_combined_report", "bracken"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["bracken", "combined-report"],
+        "tags": [TaxprofilerTags.BRACKEN, TaxprofilerTags.COMBINED_REPORT],
         "used_by": ["clinical-delivery"],
     },
     frozenset({"bracken_report", "bracken"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["bracken", "metagenomics-report"],
+        "tags": [TaxprofilerTags.BRACKEN, TaxprofilerTags.METAGENOMICS_REPORT],
         "used_by": ["clinical-delivery"],
     },
     frozenset({"centrifuge_combined_report", "centrifuge"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["centrifuge", "combined-report"],
+        "tags": [TaxprofilerTags.CENTRIFUGE, TaxprofilerTags.COMBINED_REPORT],
         "used_by": ["clinical-delivery"],
     },
     frozenset({"centrifuge_report", "centrifuge"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["centrifuge", "metagenomics-report"],
+        "tags": [TaxprofilerTags.CENTRIFUGE, TaxprofilerTags.METAGENOMICS_REPORT],
         "used_by": ["clinical-delivery"],
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["multiqc-html"],
+        "tags": [ReportTags.MULTIQC_HTML],
         "used_by": ["clinical-delivery", "long-term-storage"],
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
-        "tags": ["multiqc-json"],
+        "tags": [ReportTags.MULTIQC_JSON],
         "used_by": ["clinical-delivery", "long-term-storage"],
     },
     frozenset({"qc-metrics"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics"],
+        "tags": [QCTags.QC_METRICS],
         "used_by": ["cg", "long-term-storage"],
     },
-    frozenset({"multiqc-general-stats", "multiqc"}): {
+    frozenset({"multiqc-json", "multiqc-general-stats"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "general-stats"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.GENERAL_STATS],
         "used_by": ["janus"],
     },
-    frozenset({"multiqc-fastp", "multiqc"}): {
+    frozenset({"multiqc-json", "multiqc-fastp"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "fastp"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, BioinfoToolsTags.FASTP],
         "used_by": ["janus"],
     },
-    frozenset({"multiqc-samtools-stats", "multiqc"}): {
+    frozenset({"multiqc-json", "multiqc-samtools-stats"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "samtools-stats"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.SAMTOOLS_STATS],
         "used_by": ["janus"],
     },
-    frozenset({"multiqc-kraken", "multiqc"}): {
+    frozenset({"multiqc-json", "multiqc-kraken"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "kraken2"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, TaxprofilerTags.KRAKEN2],
         "used_by": ["janus"],
     },
 }

--- a/docs/taxprofiler_map.md
+++ b/docs/taxprofiler_map.md
@@ -12,7 +12,7 @@
 | multiqc-json                           | True      | multiqc-json                        | clinical-delivery, long-term-storage |
 | qc-metrics                             | True      | qc-metrics                          | cg, long-term-storage                |
 | software-versions                      | True      | software-versions                   | cg                                   |
-| multiqc-general-stats, multiqc         | True      | qc-metrics, multiqc, general-stats  | janus                                |
-| multiqc-fastp, multiqc                 | True      | qc-metrics, multiqc, fastp          | janus                                |
-| multiqc-samtools-stats, multiqc        | True      | qc-metrics, multiqc, samtools-stats | janus                                |
-| multiqc-kraken, multiqc                | True      | qc-metrics, multiqc, kraken2        | janus                                |
+| multiqc-general-stats, multiqc-json    | True      | qc-metrics, multiqc, general-stats  | janus                                |
+| multiqc-fastp, multiqc-json            | True      | qc-metrics, multiqc, fastp          | janus                                |
+| multiqc-samtools-stats, multiqc-json   | True      | qc-metrics, multiqc, samtools-stats | janus                                |
+| multiqc-kraken, multiqc-json           | True      | qc-metrics, multiqc, kraken2        | janus                                |

--- a/docs/taxprofiler_map.md
+++ b/docs/taxprofiler_map.md
@@ -1,14 +1,18 @@
-| Taxprofiler tags                       | Mandatory   | HK tags                          | Used by                              |
-|----------------------------------------|-------------|----------------------------------|--------------------------------------|
-| kraken2, kraken2_combined_report       | True        | kraken2, combined-report         | clinical-delivery, long-term-storage |
-| kraken2, kraken2_report                | True        | kraken2, metagenomics-report     | clinical-delivery, long-term-storage |
-| krona, krona_kraken_plot               | True        | kraken2, krona, visualization    | clinical-delivery, long-term-storage |
-| krona, krona_centrifuge_plot           | True        | centrifuge, krona, visualization | clinical-delivery                    |
-| bracken, bracken_combined_report       | True        | bracken, combined-report         | clinical-delivery                    |
-| bracken, bracken_report                | True        | bracken, metagenomics-report     | clinical-delivery                    |
-| centrifuge, centrifuge_combined_report | True        | centrifuge, combined-report      | clinical-delivery                    |
-| centrifuge_report, centrifuge          | True        | centrifuge, metagenomics-report  | clinical-delivery                    |
-| report, multiqc-html                   | True        | multiqc-html                     | clinical-delivery, long-term-storage |
-| multiqc-json                           | True        | multiqc-json                     | clinical-delivery, long-term-storage |
-| qc-metrics                             | True        | qc-metrics                       | cg, long-term-storage                |
-| software-versions                      | True        | software-versions                | cg                                   |
+| Taxprofiler tags                       | Mandatory | HK tags                             | Used by                              |
+|----------------------------------------|-----------|-------------------------------------|--------------------------------------|
+| kraken2, kraken2_combined_report       | True      | kraken2, combined-report            | clinical-delivery, long-term-storage |
+| kraken2, kraken2_report                | True      | kraken2, metagenomics-report        | clinical-delivery, long-term-storage |
+| krona, krona_kraken_plot               | True      | kraken2, krona, visualization       | clinical-delivery, long-term-storage |
+| krona, krona_centrifuge_plot           | True      | centrifuge, krona, visualization    | clinical-delivery                    |
+| bracken, bracken_combined_report       | True      | bracken, combined-report            | clinical-delivery                    |
+| bracken, bracken_report                | True      | bracken, metagenomics-report        | clinical-delivery                    |
+| centrifuge, centrifuge_combined_report | True      | centrifuge, combined-report         | clinical-delivery                    |
+| centrifuge_report, centrifuge          | True      | centrifuge, metagenomics-report     | clinical-delivery                    |
+| report, multiqc-html                   | True      | multiqc-html                        | clinical-delivery, long-term-storage |
+| multiqc-json                           | True      | multiqc-json                        | clinical-delivery, long-term-storage |
+| qc-metrics                             | True      | qc-metrics                          | cg, long-term-storage                |
+| software-versions                      | True      | software-versions                   | cg                                   |
+| multiqc-general-stats, multiqc         | True      | qc-metrics, multiqc, general-stats  | janus                                |
+| multiqc-fastp, multiqc                 | True      | qc-metrics, multiqc, fastp          | janus                                |
+| multiqc-samtools-stats, multiqc        | True      | qc-metrics, multiqc, samtools-stats | janus                                |
+| multiqc-kraken, multiqc                | True      | qc-metrics, multiqc, kraken2        | janus                                |

--- a/tests/fixtures/taxprofiler/case_id_deliverables.yaml
+++ b/tests/fixtures/taxprofiler/case_id_deliverables.yaml
@@ -72,3 +72,28 @@ files:
   path_index: null
   step: qc-metrics
   tag: qc-metrics
+- format: json
+  id: CASE_ID
+  path: /CASE_ID/multiqc/multiqc_data/multiqc_general_stats.json
+  path_index: null
+  step: multiqc-json
+  tag: multiqc-general-stats
+- format: json
+  id: CASE_ID
+  path: /CASE_ID/multiqc/multiqc_data/multiqc_fastp.json
+  path_index: null
+  step: multiqc-json
+  tag: multiqc-fastp
+- format: json
+  id: CASE_ID
+  path: /CASE_ID/multiqc/multiqc_data/multiqc_kraken.json
+  path_index: null
+  step: multiqc-json
+  tag: multiqc-kraken
+- format: json
+  id: CASE_ID
+  path: /CASE_ID/multiqc/multiqc_data/multiqc_samtools_stats.json
+  path_index: null
+  step: multiqc-json
+  tag: multiqc-samtools-stats
+


### PR DESCRIPTION
## Added

* MultiQC intermediate files to HK

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b taxprofiler_intermediate_json_files`

### How to test
- [ ] `housekeeper get bundle -v propersheep`

![Screenshot 2024-04-15 at 15 12 13](https://github.com/Clinical-Genomics/hermes/assets/91951607/c5bb8243-d5b8-4467-960c-fa4eae609f53)


### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
