### PR TITLE
Force storage of incomplete analyses

### DIFF
--- a/cg_hermes/cli/common.py
+++ b/cg_hermes/cli/common.py
@@ -13,7 +13,12 @@ LOG = logging.getLogger(__name__)
 
 
 def get_deliverables(deliverables_file: Path) -> dict[str, list[dict[str, str]]]:
-    """Open file and load into a dictionary. Try to first open YAML, then JSON."""
+    """
+    Open file and load into a dictionary. Try to first open YAML, then JSON.
+
+    Raises:
+        typer.Abort: If the file cannot be parsed as YAML or JSON.
+    """
     with open(deliverables_file, "r") as handle:
         try:
             deliverables = yaml.load(handle, Loader=yaml.SafeLoader)

--- a/cg_hermes/cli/common.py
+++ b/cg_hermes/cli/common.py
@@ -17,13 +17,13 @@ def get_deliverables(deliverables_file: Path) -> dict[str, list[dict[str, str]]]
     with open(deliverables_file, "r") as handle:
         try:
             deliverables = yaml.load(handle, Loader=yaml.SafeLoader)
-        except ParserError as err:
-            LOG.error(err)
+        except ParserError as error:
+            LOG.error(error)
             LOG.warning(f"File {deliverables_file} is not in YAML format")
             try:
                 deliverables = json.load(handle)
-            except JSONDecodeError as err:
-                LOG.error(err)
+            except JSONDecodeError as error:
+                LOG.error(error)
                 LOG.warning(f"File {deliverables_file} is not in JSON format")
                 LOG.warning("Can not parse file")
                 raise typer.Abort()

--- a/cg_hermes/cli/common.py
+++ b/cg_hermes/cli/common.py
@@ -1,4 +1,5 @@
 """Store common utilities."""
+
 import json
 import logging
 from json.decoder import JSONDecodeError
@@ -11,22 +12,19 @@ from yaml.parser import ParserError
 LOG = logging.getLogger(__name__)
 
 
-def get_deliverables(infile: Path) -> dict[str, list[dict[str, str]]]:
-    """Open file and load into dict.
-
-    Try to first open yaml, then json.
-    """
-    with open(infile, "r") as handle:
+def get_deliverables(deliverables_file: Path) -> dict[str, list[dict[str, str]]]:
+    """Open file and load into a dictionary. Try to first open YAML, then JSON."""
+    with open(deliverables_file, "r") as handle:
         try:
             deliverables = yaml.load(handle, Loader=yaml.SafeLoader)
         except ParserError as err:
             LOG.error(err)
-            LOG.warning(f"File {infile} is not in yaml format")
+            LOG.warning(f"File {deliverables_file} is not in YAML format")
             try:
                 deliverables = json.load(handle)
             except JSONDecodeError as err:
                 LOG.error(err)
-                LOG.warning(f"File {infile} is not in json format")
+                LOG.warning(f"File {deliverables_file} is not in JSON format")
                 LOG.warning("Can not parse file")
                 raise typer.Abort()
         return deliverables

--- a/cg_hermes/cli/convert.py
+++ b/cg_hermes/cli/convert.py
@@ -21,23 +21,23 @@ app = typer.Typer()
 
 @app.command(name="deliverables")
 def convert_cmd(
-    infile: Path,
+    deliverables_file: Path,
     workflow: Workflow = typer.Option(..., help="Specify the workflow"),
     analysis_type: CancerAnalysisType = typer.Option(None, help="Specify the analysis type"),
+    force: bool = typer.Option(False, "--force", "-f", help="Bypass deliverables file validation"),
 ):
-    LOG.info(f"Convert deliverable file: {infile} from workflow {workflow} to CG format")
-
-    raw_deliverables: dict[str, list[dict[str, str]]] = get_deliverables(infile)
+    LOG.info(f"Convert deliverable file: {deliverables_file} from workflow {workflow} to CG format")
+    raw_deliverables: dict[str, list[dict[str, str]]] = get_deliverables(deliverables_file)
     try:
         deliverables: Deliverables = get_deliverables_obj(
             deliverables=raw_deliverables, workflow=workflow, analysis_type=analysis_type
         )
-        deliverables.validate_mandatory_files()
+        deliverables.validate_mandatory_files(force)
     except SyntaxError:
         raise typer.Abort()
     except (ValidationError, MissingFileError) as err:
         LOG.error(err)
-        LOG.warning(f"File: {infile} does not follow the specification")
+        LOG.warning(f"File: {deliverables_file} does not follow the specification")
         raise typer.Abort()
 
     cg_deliverables: CGDeliverables = deliverables.convert_to_cg_deliverables()

--- a/cg_hermes/cli/convert.py
+++ b/cg_hermes/cli/convert.py
@@ -25,7 +25,13 @@ def convert_cmd(
     workflow: Workflow = typer.Option(..., help="Specify the workflow"),
     analysis_type: CancerAnalysisType = typer.Option(None, help="Specify the analysis type"),
     force: bool = typer.Option(False, "--force", "-f", help="Bypass deliverables file validation"),
-):
+) -> None:
+    """
+    Convert deliverable file to CG format.
+
+    Raises:
+        typer.Abort: If an error occurs during conversion or validation.
+    """
     LOG.info(f"Convert deliverable file: {deliverables_file} from workflow {workflow} to CG format")
     raw_deliverables: dict[str, list[dict[str, str]]] = get_deliverables(deliverables_file)
     try:
@@ -40,6 +46,5 @@ def convert_cmd(
         LOG.error(error)
         LOG.error(f"File: {deliverables_file} does not follow the specification")
         raise typer.Abort()
-
     cg_deliverables: CGDeliverables = deliverables.convert_to_cg_deliverables()
     typer.echo(json.dumps(cg_deliverables.dict(), indent=2))

--- a/cg_hermes/cli/convert.py
+++ b/cg_hermes/cli/convert.py
@@ -33,13 +33,13 @@ def convert_cmd(
             deliverables=raw_deliverables, workflow=workflow, analysis_type=analysis_type
         )
         deliverables.validate_mandatory_files(force)
-    except SyntaxError:
+    except SyntaxError as error:
+        LOG.error(error)
         raise typer.Abort()
-    except (ValidationError, MissingFileError) as err:
-        LOG.error(err)
-        LOG.warning(f"File: {deliverables_file} does not follow the specification")
+    except (ValidationError, MissingFileError) as error:
+        LOG.error(error)
+        LOG.error(f"File: {deliverables_file} does not follow the specification")
         raise typer.Abort()
 
     cg_deliverables: CGDeliverables = deliverables.convert_to_cg_deliverables()
-
     typer.echo(json.dumps(cg_deliverables.dict(), indent=2))

--- a/cg_hermes/cli/validate.py
+++ b/cg_hermes/cli/validate.py
@@ -27,25 +27,24 @@ app = typer.Typer()
 
 @app.command("deliverables")
 def validate_deliverables(
-    infile: Path,
+    deliverables_file: Path,
     workflow: Workflow = typer.Option(Workflow.FLUFFY, help="Specify workflow"),
     analysis_type: CancerAnalysisType = typer.Option(None, help="Specify the analysis type"),
+    force: bool = typer.Option(False, "--force", "-f", help="Bypass deliverables file validation"),
 ):
     """Validate a deliverables file."""
-    LOG.info(f"Validating file: {infile} from workflow: {workflow}")
-
-    raw_deliverables: dict[str, list[dict[str, str]]] = get_deliverables(infile)
-
+    LOG.info(f"Validating file: {deliverables_file} from workflow: {workflow}")
+    raw_deliverables: dict[str, list[dict[str, str]]] = get_deliverables(deliverables_file)
     try:
         deliverables: Deliverables = get_deliverables_obj(
             deliverables=raw_deliverables, workflow=workflow, analysis_type=analysis_type
         )
-        deliverables.validate_mandatory_files()
+        deliverables.validate_mandatory_files(force)
     except SyntaxError:
         raise typer.Abort()
     except (ValidationError, MissingFileError) as err:
         LOG.error(err)
-        LOG.warning(f"File {infile} does not follow the spec")
+        LOG.warning(f"File {deliverables_file} does not follow the spec")
         raise typer.Abort()
     LOG.info("Deliverables file has the correct format")
 

--- a/cg_hermes/deliverables.py
+++ b/cg_hermes/deliverables.py
@@ -200,16 +200,19 @@ class Deliverables:
             updated_tags[tag_name]["is_mandatory"] = tag_info["is_mandatory"]
         return updated_tags
 
-    def validate_mandatory_files(self) -> None:
-        """Validate that all mandatory files are present in deliverables"""
+    def validate_mandatory_files(self, force: bool = False) -> None:
+        """Validate that all mandatory files are present in deliverables."""
         missing_mandatory_files = []
         for file_tags in self.configs:
             if not self.configs[file_tags].is_mandatory:
                 continue
             if file_tags not in self.file_identifiers:
-                LOG.warning("Mandatory file (%s) is missing", ", ".join(file_tags))
+                LOG.warning(f"Mandatory file ({', '.join(file_tags)}) is missing")
                 missing_mandatory_files.append(", ".join(file_tags))
         if missing_mandatory_files:
+            if force:
+                LOG.warning("Ignoring deliverables file validation")
+                return
             raise MissingFileError(
                 files=missing_mandatory_files, message="Deliverables is missing mandatory files"
             )


### PR DESCRIPTION
## Description

This PR will allow us to force the generation of the HK bundle of failed analyses. It addresses some of the points from https://github.com/Clinical-Genomics/cg/issues/2702.

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b [THIS-BRANCH-NAME]`

### How to test
- `/hermes validate deliverables --workflow <workflow>`
- `/hermes convert deliverables --workflow <workflow>`
- Tested as part of https://github.com/Clinical-Genomics/cg/pull/3340

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
