### PR TITLE
Add clinical-delivery and long-term-storage tags to Rnafusion

### DIFF
--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -5,69 +5,70 @@ mandatory by default. However the tags that are available to a particular analys
 """
 
 from cg_hermes.config.nextflow import NEXTFLOW_TAGS
+from cg_hermes.constants.tags import UsageTags
 
 RNAFUSION_COMMON_TAGS = {
     frozenset({"arriba"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": ["arriba", "fusion"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"arriba-visualisation", "arriba"}): {
         "is_mandatory": False,
         "bundle_id": True,
         "tags": ["arriba-visualisation", "visualization", "arriba", "research"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioncatcher"}): {
         "is_mandatory": True,
         "tags": ["fusioncatcher", "fusion"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioncatcher-summary", "fusioncatcher"}): {
         "is_mandatory": True,
         "tags": ["fusioncatcher-summary"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion"}): {
         "is_mandatory": True,
         "tags": ["star-fusion", "fusion"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusionreport", "report"}): {
         "is_mandatory": True,
         "tags": ["fusionreport", "research"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioninspector", "report"}): {
         "is_mandatory": False,
         "tags": ["fusioninspector"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioninspector-html", "report"}): {
         "is_mandatory": False,
         "tags": ["fusioninspector-html", "research"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
         "tags": ["multiqc-html", "rna"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion-cram", "star-fusion"}): {
         "is_mandatory": True,
         "tags": ["cram"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion-cram-index", "star-fusion"}): {
         "is_mandatory": True,
         "tags": ["cram-index"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-align-gene-counts", "star-align"}): {
         "is_mandatory": True,
         "tags": ["gene-counts"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
@@ -77,7 +78,7 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"vcf-fusion", "vcf-collect"}): {
         "is_mandatory": False,
         "tags": ["vcf-fusion"],
-        "used_by": ["deliver", "scout"],
+        "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-fastp", "multiqc"}): {
         "is_mandatory": True,

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -22,7 +22,7 @@ RNAFUSION_COMMON_TAGS = {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": [BioinfoToolsTags.ARRIBA, AnalysisTags.FUSION],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"arriba-visualisation", "arriba"}): {
         "is_mandatory": False,
@@ -33,12 +33,12 @@ RNAFUSION_COMMON_TAGS = {
             BioinfoToolsTags.ARRIBA,
             AnalysisTags.RESEARCH,
         ],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"fusioncatcher"}): {
         "is_mandatory": True,
         "tags": [BioinfoToolsTags.FUSIONCATCHER, AnalysisTags.FUSION],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"fusioncatcher-summary", "fusioncatcher"}): {
         "is_mandatory": True,
@@ -48,27 +48,27 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"star-fusion"}): {
         "is_mandatory": True,
         "tags": [BioinfoToolsTags.STAR_FUSION, AnalysisTags.FUSION],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"fusionreport", "report"}): {
         "is_mandatory": True,
         "tags": [RnafusionTags.FUSIONREPORT, AnalysisTags.RESEARCH],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"fusioninspector", "report"}): {
         "is_mandatory": False,
         "tags": [BioinfoToolsTags.FUSIONINSPECTOR],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"fusioninspector-html", "report"}): {
         "is_mandatory": False,
         "tags": [RnafusionTags.FUSIONINSPECTOR_HTML, AnalysisTags.RESEARCH],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
         "tags": [ReportTags.MULTIQC_HTML, RawDataTags.RNA],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"star-fusion-cram", "star-fusion"}): {
         "is_mandatory": True,
@@ -83,7 +83,7 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"star-align-gene-counts", "star-align"}): {
         "is_mandatory": True,
         "tags": [ReportTags.GENE_COUNTS],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
@@ -93,7 +93,7 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"vcf-fusion", "vcf-collect"}): {
         "is_mandatory": False,
         "tags": [AnalysisTags.VCF_FUSION],
-        "used_by": [UsageTags.CLINICAL_DELIVERY],
+        "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset({"multiqc-fastp", "multiqc"}): {
         "is_mandatory": True,

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -73,7 +73,7 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
         "tags": ["multiqc-json"],
-        "used_by": ["deliver"],
+        "used_by": [UsageTags.CG],
     },
     frozenset({"vcf-fusion", "vcf-collect"}): {
         "is_mandatory": False,
@@ -83,38 +83,38 @@ RNAFUSION_COMMON_TAGS = {
     frozenset({"multiqc-fastp", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "fastp"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-duplicates", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "picard-duplicates"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-insert-size", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "picard-insert-size"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-rnaseq", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "picard-rnaseq"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-general-stats", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "general-stats"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-star", "multiqc"}): {
         "is_mandatory": True,
         "tags": ["qc-metrics", "multiqc", "star"],
-        "used_by": ["janus"],
+        "used_by": [UsageTags.JANUS],
     },
     frozenset({"samplesheet-valid"}): {
         "is_mandatory": True,
         "bundle_id": True,
         "tags": ["samplesheet-valid"],
-        "used_by": ["cg"],
+        "used_by": [UsageTags.CG],
     },
 }
 

--- a/cg_hermes/config/rnafusion.py
+++ b/cg_hermes/config/rnafusion.py
@@ -5,115 +5,130 @@ mandatory by default. However the tags that are available to a particular analys
 """
 
 from cg_hermes.config.nextflow import NEXTFLOW_TAGS
-from cg_hermes.constants.tags import UsageTags
+from cg_hermes.constants.tags import (
+    AlignmentTags,
+    AnalysisTags,
+    BioinfoToolsTags,
+    NextflowTags,
+    QCTags,
+    RawDataTags,
+    ReportTags,
+    RnafusionTags,
+    UsageTags,
+)
 
 RNAFUSION_COMMON_TAGS = {
     frozenset({"arriba"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["arriba", "fusion"],
+        "tags": [BioinfoToolsTags.ARRIBA, AnalysisTags.FUSION],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"arriba-visualisation", "arriba"}): {
         "is_mandatory": False,
         "bundle_id": True,
-        "tags": ["arriba-visualisation", "visualization", "arriba", "research"],
+        "tags": [
+            RnafusionTags.ARRIBA_VISUALISATION,
+            AnalysisTags.VISUALIZATION,
+            BioinfoToolsTags.ARRIBA,
+            AnalysisTags.RESEARCH,
+        ],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioncatcher"}): {
         "is_mandatory": True,
-        "tags": ["fusioncatcher", "fusion"],
+        "tags": [BioinfoToolsTags.FUSIONCATCHER, AnalysisTags.FUSION],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioncatcher-summary", "fusioncatcher"}): {
         "is_mandatory": True,
-        "tags": ["fusioncatcher-summary"],
+        "tags": [BioinfoToolsTags.FUSIONCATCHER_SUMMARY],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion"}): {
         "is_mandatory": True,
-        "tags": ["star-fusion", "fusion"],
+        "tags": [BioinfoToolsTags.STAR_FUSION, AnalysisTags.FUSION],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusionreport", "report"}): {
         "is_mandatory": True,
-        "tags": ["fusionreport", "research"],
+        "tags": [RnafusionTags.FUSIONREPORT, AnalysisTags.RESEARCH],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioninspector", "report"}): {
         "is_mandatory": False,
-        "tags": ["fusioninspector"],
+        "tags": [BioinfoToolsTags.FUSIONINSPECTOR],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"fusioninspector-html", "report"}): {
         "is_mandatory": False,
-        "tags": ["fusioninspector-html", "research"],
+        "tags": [RnafusionTags.FUSIONINSPECTOR_HTML, AnalysisTags.RESEARCH],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-html", "report"}): {
         "is_mandatory": True,
-        "tags": ["multiqc-html", "rna"],
+        "tags": [ReportTags.MULTIQC_HTML, RawDataTags.RNA],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion-cram", "star-fusion"}): {
         "is_mandatory": True,
-        "tags": ["cram"],
+        "tags": [AlignmentTags.CRAM],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-fusion-cram-index", "star-fusion"}): {
         "is_mandatory": True,
-        "tags": ["cram-index"],
+        "tags": [AlignmentTags.CRAM_INDEX],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"star-align-gene-counts", "star-align"}): {
         "is_mandatory": True,
-        "tags": ["gene-counts"],
+        "tags": [ReportTags.GENE_COUNTS],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-json"}): {
         "is_mandatory": True,
-        "tags": ["multiqc-json"],
+        "tags": [ReportTags.MULTIQC_JSON],
         "used_by": [UsageTags.CG],
     },
     frozenset({"vcf-fusion", "vcf-collect"}): {
         "is_mandatory": False,
-        "tags": ["vcf-fusion"],
+        "tags": [AnalysisTags.VCF_FUSION],
         "used_by": [UsageTags.CLINICAL_DELIVERY],
     },
     frozenset({"multiqc-fastp", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "fastp"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, BioinfoToolsTags.FASTP],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-duplicates", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "picard-duplicates"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.PICARD_DUPLICATES],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-insert-size", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "picard-insert-size"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.PICARD_INSERT_SIZE],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-picard-rnaseq", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "picard-rnaseq"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.PICARD_RNASEQ],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-general-stats", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "general-stats"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.GENERAL_STATS],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"multiqc-star", "multiqc"}): {
         "is_mandatory": True,
-        "tags": ["qc-metrics", "multiqc", "star"],
+        "tags": [QCTags.QC_METRICS, ReportTags.MULTIQC, ReportTags.STAR],
         "used_by": [UsageTags.JANUS],
     },
     frozenset({"samplesheet-valid"}): {
         "is_mandatory": True,
         "bundle_id": True,
-        "tags": ["samplesheet-valid"],
+        "tags": [NextflowTags.SAMPLESHEET_VALID],
         "used_by": [UsageTags.CG],
     },
 }


### PR DESCRIPTION
## Description

Tested in https://github.com/Clinical-Genomics/cg/pull/3526


### Added:
- Add clinical-delivery and long-term-storage tags to Rnafusion

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_hermes -t hermes -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
