### PR TITLE
Add bigbed tag to mip-dna upd files

### DIFF
--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -249,12 +249,12 @@ MIP_DNA_TAGS = {
         "used_by": ["scout"],
     },
     frozenset(["upd_ar", "regions"]): {
-        "tags": ["upd", "regions"],
+        "tags": ["upd", "regions", "bigbed"],
         "is_mandatory": False,
         "used_by": ["scout"],
     },
     frozenset(["upd_ar", "sites"]): {
-        "tags": ["upd", "sites"],
+        "tags": ["upd", "sites", "bigbed"],
         "is_mandatory": False,
         "used_by": ["scout"],
     },

--- a/cg_hermes/constants/tags.py
+++ b/cg_hermes/constants/tags.py
@@ -304,6 +304,7 @@ class AnalysisTags(StrEnum):
     AUTOZYG: str = "autozyg"
     BED: str = "bed"
     BED_INDEX: str = "bed-index"
+    BIGBED: str = "bigbed"
     BIGWIG: str = "bigwig"
     CIRCULAR_PLOT: str = "circular-plot"
     CLINICAL: str = "clinical"
@@ -351,6 +352,7 @@ class AnalysisTags(StrEnum):
             self.AUTOZYG: "Autozygous region",
             self.BED: "Bed file",
             self.BED_INDEX: "Following index",
+            self.BIGBED: "BigBed file",
             self.BIGWIG: "Bigwig formatted file",
             self.CIRCULAR_PLOT: "Circular plot",
             self.CLINICAL: "Clinical subset",

--- a/cg_hermes/deliverables.py
+++ b/cg_hermes/deliverables.py
@@ -217,7 +217,6 @@ class Deliverables:
         files: list[TagBase] = []
         for file_obj in self.model.files:
             identifier = [file_obj.step]
-            path = file_obj.path
             if file_obj.tag:
                 identifier.append(file_obj.tag)
             files.append(

--- a/cg_hermes/deliverables.py
+++ b/cg_hermes/deliverables.py
@@ -217,6 +217,7 @@ class Deliverables:
         files: list[TagBase] = []
         for file_obj in self.model.files:
             identifier = [file_obj.step]
+            path = file_obj.path
             if file_obj.tag:
                 identifier.append(file_obj.tag)
             files.append(


### PR DESCRIPTION
## Description

### Added

- `bigbed` tag to mip-dna upd files.

Note: Added tag to the housekeeper database as well. 

## Testing

### How to prepare for test

- [x] ssh to Hasta

```bash
hermes-test-deploy 4275-add-bigbed-tag-to-upd-files
```

### How to test

- [x] Given a <case_id> which is a trio, run:

```bash
us
cg workflow mip-dna store <case_id>
```

### Expected test result
- [x] Check that the tag `bigbed` is added to the `*.sites.bb` and `*.regions.bb`
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by BSV
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
