### PR TITLE
Raredisease: change mosdepth to d4tools output in hk bundle

### DIFF
--- a/cg_hermes/config/raredisease.py
+++ b/cg_hermes/config/raredisease.py
@@ -45,7 +45,7 @@ RAREDISEASE_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT],
     },
-    frozenset(["qc_bam", "mosdepth_d4"]): {
+    frozenset(["qc_bam", "d4tools_d4"]): {
         "tags": [AnalysisTags.COVERAGE, ReportTags.D4],
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT],

--- a/docs/raredisease_map.md
+++ b/docs/raredisease_map.md
@@ -5,7 +5,7 @@
 | alignment, alignment_mt                          | False       | bam-mt                               | scout                                          |
 | alignment_mt_index, alignment                    | False       | bam-mt-index                         | scout                                          |
 | tiddit_coverage                                  | False       | tiddit-coverage, bigwig              | scout                                          |
-| mosdepth_d4, qc_bam                              | False       | coverage, d4                         | scout                                          |
+| d4tools_d4, qc_bam                              | False       | coverage, d4                         | scout                                          |
 | tcov, chromograph_cov                            | False       | chromograph, tcov                    | scout                                          |
 | smncopynumbercaller, tsv                         | False       | smn-calling                          | scout, clinical-delivery, long-term-storage    |
 | variant_catalog, expansionhunter                 | False       | expansionhunter, variant-catalog     | scout, long-term-storage                       |

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -27,9 +27,9 @@ files:
   tag: tiddit_coverage
 - format: meta
   id: SAMPLEID
-  path: PATHTOCASE/qc_bam/SAMPLEID_mosdepth.per-base.d4
+  path: PATHTOCASE/qc_bam/SAMPLEID.d4
   step: qc_bam
-  tag: mosdepth_d4
+  tag: d4tools_d4
 - format: png
   id: SAMPLEID
   path: PATHTOCASE/qc_bam/SAMPLEID_chromographcov/SAMPLEID_tidditcov_1.png


### PR DESCRIPTION
## Description
For raredisease 2.5.3 we are removing the mosdepth output and instead delivering d4 files generated by d4tools. This PR updates the cg tag names.

To be deployed at the same time as the Servers PR switching to raredisease 2.5.3.

### Added

-

### Changed

- Raredisease: change mosdepth to d4tools output in hk bundle

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy raredisease-change-mosdepth-to-d4tools
hermes-test <command here>
```

### How to test
- [x] login to hasta and us
- [x] Deploy the corresponding cg PR as well https://github.com/Clinical-Genomics/cg/pull/4632
- [x] do `cg workflow raredisease store anotheramusedmarmoset`

### Expected test result
- [x] check that there are 3 d4 files in the hk bundle, and show correct tags (unchanged tags)
- [x] Take a screenshot and attach or copy/paste the output.
<img width="951" height="67" alt="image" src="https://github.com/user-attachments/assets/5935e6ae-a538-418c-81ed-df1c8e6032e6" />

<img width="956" height="18" alt="image" src="https://github.com/user-attachments/assets/ab3d37eb-db27-4dae-97e2-af0d0ecbf5fc" />


## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
