### PR TITLE
Add Mip-DNA deepvariant report

### DIFF
--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -164,7 +164,7 @@ MIP_DNA_TAGS = {
         "is_mandatory": True,
         "used_by": ["storage"],
     },
-    frozenset(["deepvariant", "report"]): {
+    frozenset(["deepvariant"]): {
         "tags": ["deepvariant-report"],
         "is_mandatory": True,
         "used_by": ["storage"],

--- a/cg_hermes/config/mip_dna.py
+++ b/cg_hermes/config/mip_dna.py
@@ -164,6 +164,11 @@ MIP_DNA_TAGS = {
         "is_mandatory": True,
         "used_by": ["storage"],
     },
+    frozenset(["deepvariant", "report"]): {
+        "tags": ["deepvariant-report"],
+        "is_mandatory": True,
+        "used_by": ["storage"],
+    },
     frozenset(["mitodel"]): {
         "tags": ["mitodel"],
         "is_mandatory": False,

--- a/docs/mip-dna_map.md
+++ b/docs/mip-dna_map.md
@@ -29,6 +29,7 @@
 | mip_analyse, sample_info            | True        | sample-info                      | cg, audit    |
 | html, multiqc_ar                    | True        | multiqc-html                     | scout        |
 | json, multiqc_ar                    | True        | multiqc-json                     | storage      |
+| deepvariant, report                 | True        | deepvariant-report               | storage      |
 | mitodel                             | False       | mitodel                          | scout        |
 | ped_check, peddy_ar                 | True        | peddy, ped-check                 | audit, scout |
 | peddy_ar, peddy                     | True        | peddy, ped                       | audit, scout |

--- a/docs/mip-dna_map.md
+++ b/docs/mip-dna_map.md
@@ -29,7 +29,7 @@
 | mip_analyse, sample_info            | True        | sample-info                      | cg, audit    |
 | html, multiqc_ar                    | True        | multiqc-html                     | scout        |
 | json, multiqc_ar                    | True        | multiqc-json                     | storage      |
-| deepvariant, report                 | True        | deepvariant-report               | storage      |
+| deepvariant                         | True        | deepvariant-report               | storage      |
 | mitodel                             | False       | mitodel                          | scout        |
 | ped_check, peddy_ar                 | True        | peddy, ped-check                 | audit, scout |
 | peddy_ar, peddy                     | True        | peddy, ped                       | audit, scout |

--- a/tests/fixtures/mip_dna/case_id_deliverables.yaml
+++ b/tests/fixtures/mip_dna/case_id_deliverables.yaml
@@ -154,6 +154,12 @@ files:
     path_index: ~
     step: multiqc_ar
     tag: json
+  - format: meta
+    id: sample_id
+    path: /path/to/rare-disease/cases/case_id/analysis/sample_id/deepvariant/sample_id.visual_report.html
+    path_index: ~
+    step: deepvariant
+    tag: ~
   - format: bcf
     id: case_id
     path: /path/to/rare-disease/cases/case_id/analysis/case_id/gatk_combinevariantcallsets/case_id_gatkcomb.bcf

--- a/tests/fixtures/mip_dna/case_id_deliverables.yaml
+++ b/tests/fixtures/mip_dna/case_id_deliverables.yaml
@@ -159,7 +159,7 @@ files:
     path: /path/to/rare-disease/cases/case_id/analysis/sample_id/deepvariant/sample_id.visual_report.html
     path_index: ~
     step: deepvariant
-    tag: ~
+    tag: report
   - format: bcf
     id: case_id
     path: /path/to/rare-disease/cases/case_id/analysis/case_id/gatk_combinevariantcallsets/case_id_gatkcomb.bcf

--- a/tests/fixtures/mip_dna/case_id_deliverables.yaml
+++ b/tests/fixtures/mip_dna/case_id_deliverables.yaml
@@ -159,7 +159,7 @@ files:
     path: /path/to/rare-disease/cases/case_id/analysis/sample_id/deepvariant/sample_id.visual_report.html
     path_index: ~
     step: deepvariant
-    tag: report
+    tag: ~
   - format: bcf
     id: case_id
     path: /path/to/rare-disease/cases/case_id/analysis/case_id/gatk_combinevariantcallsets/case_id_gatkcomb.bcf


### PR DESCRIPTION
## Description
This PR adds the deepvariant html report to the mip-dna deliverables. To be deployed at the same time as the mip change.

### Added

- deepvariant html report to the mip-dna deliverables

### Changed

-

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy add-mip-dna-deepvariant-report
```

### How to test
- [ ] login to ...
- [ ] do `cg workflow mip-dna store howmanymarmoset`

### Expected test result
- [ ] check that the deepvariant reports are in the housekeeper bundle
- [ ] Take a screenshot and attach or copy/paste the output.
<img width="1826" height="462" alt="image" src="https://github.com/user-attachments/assets/1539ff5f-eb58-4008-9141-1a80f9b33138" />


## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
