### PR TITLE
Update raredisease with saltshaker, combined nuc+mito SVs

### DIFF
--- a/cg_hermes/config/raredisease.py
+++ b/cg_hermes/config/raredisease.py
@@ -186,7 +186,7 @@ RAREDISEASE_COMMON_TAGS = {
         "used_by": [UsageTags.SCOUT],
     },
     frozenset(["call_sv_mt", "call_sv_mt"]): {
-        "tags": [RarediseaseTags.SALTSHAKER_CLASSIFY, ReportTags.TXT, AnalysisTags.MITOCHONDRIA],
+        "tags": [RarediseaseTags.SALTSHAKER_CLASSIFY, ReportTags.HTML, AnalysisTags.MITOCHONDRIA],
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
     },

--- a/cg_hermes/config/raredisease.py
+++ b/cg_hermes/config/raredisease.py
@@ -180,35 +180,20 @@ RAREDISEASE_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": [UsageTags.CG, UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
-    frozenset(["call_sv_mt", "call_sv_mt"]): {
-        "tags": [VariantTags.VCF_SV, AnalysisTags.MITOCHONDRIA],
-        "is_mandatory": False,
-        "used_by": [UsageTags.CG],
-    },
-    frozenset(["call_sv_mt", "call_sv_mt_index"]): {
-        "tags": [VariantTags.VCF_SV_INDEX, AnalysisTags.MITOCHONDRIA],
-        "is_mandatory": False,
-        "used_by": [UsageTags.CG],
-    },
     frozenset(["call_sv_mt", "call_sv_mt_del"]): {
         "tags": [AnalysisTags.MITOCHONDRIA, BioinfoToolsTags.MITODEL],
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT],
     },
-    frozenset(["call_sv_mt", "eklipse_del"]): {
-        "tags": [RarediseaseTags.EKLIPSE_DEL, ReportTags.CSV, AnalysisTags.MITOCHONDRIA],
+    frozenset(["call_sv_mt", "call_sv_mt"]): {
+        "tags": [RarediseaseTags.SALTSHAKER_CLASSIFY, ReportTags.TXT, AnalysisTags.MITOCHONDRIA],
         "is_mandatory": False,
-        "used_by": [UsageTags.LONG_TERM_STORAGE],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
     },
-    frozenset(["call_sv_mt", "eklipse_png"]): {
-        "tags": [RarediseaseTags.EKLIPSE_PNG, AnalysisTags.MITOCHONDRIA],
+    frozenset(["call_sv_mt", "saltshaker_png"]): {
+        "tags": [RarediseaseTags.SALTSHAKER_PNG, AnalysisTags.MITOCHONDRIA],
         "is_mandatory": False,
-        "used_by": [UsageTags.LONG_TERM_STORAGE],
-    },
-    frozenset(["call_sv_mt", "eklipse_genes"]): {
-        "tags": [RarediseaseTags.EKLIPSE_GENES, ReportTags.CSV, AnalysisTags.MITOCHONDRIA],
-        "is_mandatory": False,
-        "used_by": [UsageTags.SCOUT],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset(["rank_and_filter", "snv_clinical"]): {
         "tags": [VariantTags.VCF_SNV_CLINICAL],

--- a/cg_hermes/config/raredisease.py
+++ b/cg_hermes/config/raredisease.py
@@ -185,7 +185,7 @@ RAREDISEASE_COMMON_TAGS = {
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT],
     },
-    frozenset(["call_sv_mt", "call_sv_mt"]): {
+    frozenset(["call_sv_mt", "saltshaker_classify"]): {
         "tags": [RarediseaseTags.SALTSHAKER_CLASSIFY, ReportTags.HTML, AnalysisTags.MITOCHONDRIA],
         "is_mandatory": False,
         "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],

--- a/cg_hermes/constants/tags.py
+++ b/cg_hermes/constants/tags.py
@@ -209,6 +209,7 @@ class ReportTags(StrEnum):
     DELIVERY_REPORT: str = "delivery-report"
     GENE_COUNTS: str = "gene-counts"
     GENERAL_STATS: str = "general-stats"
+    HTML: str = "html"
     JSON: str = "json"
     MOSDEPTH_COVDIST: str = "mosdepth-covdist"
     MOSDEPTH_CUMCOV: str = "mosdepth-cumcov"

--- a/cg_hermes/constants/tags.py
+++ b/cg_hermes/constants/tags.py
@@ -409,7 +409,6 @@ class BioinfoToolsTags(StrEnum):
     DELLY: str = "delly"
     DESEQ2: str = "deseq2"
     DNASCOP: str = "dnascope"
-    EKLIPSE: str = "eklipse"
     EXPANSIONHUNTER: str = "expansionhunter"
     FASTP: str = "fastp"
     FASTQC: str = "fastqc"
@@ -426,6 +425,7 @@ class BioinfoToolsTags(StrEnum):
     METHBAT_PILEUP: str = "methbat-pileup"
     METHBAT_PROFILE: str = "methbat-profile"
     MITODEL: str = "mitodel"
+    MITOSALT: str = "mitosalt"
     MODKIT_PILEUP: str = "modkit-pileup"
     NEXTCLADE: str = "nextclade"
     PARAPHASE: str = "paraphase"
@@ -434,6 +434,7 @@ class BioinfoToolsTags(StrEnum):
     PIZZLY: str = "pizzly"
     RETROSEQ: str = "retroseq"
     SALMON_QUANT: str = "salmon-quant"
+    SALTSHAKER: str = "saltshaker"
     SAWFISH: str = "sawfish"
     SENTION: str = "sention"
     SEVERUS: str = "severus"
@@ -472,7 +473,6 @@ class BioinfoToolsTags(StrEnum):
             self.DELLY: "Cancer structural variant prediction tool",
             self.DESEQ2: "Differential expression analysis with DESeq2",
             self.DNASCOP: "Call snv indels",
-            self.EKLIPSE: "Detection and quantification of mitochondrial DNA deletions",
             self.EXPANSIONHUNTER: "Call repeat expansions",
             self.FASTP: "Preprocessing tool for FastQ files",
             self.FASTQC: "Quality control tool for high throughput sequence data",
@@ -486,6 +486,7 @@ class BioinfoToolsTags(StrEnum):
             self.HIFICNV: "Hificnv tool output",
             self.MANTA: "Tool to call structural variants",
             self.MITODEL: "Tool to identify mitochondrial deletion signatures",
+            self.MITOSALT: "Tool to call mitochondrial deletions and duplications",
             self.MODKIT_PILEUP: "Modkit pileup tool output",
             self.NEXTCLADE: "Viral genome clade assignment",
             self.PARAPHASE: "Paraphase tool output",
@@ -494,6 +495,7 @@ class BioinfoToolsTags(StrEnum):
             self.PIZZLY: "Fusion caller",
             self.RETROSEQ: "Mobile element caller",
             self.SALMON_QUANT: "Transcript quantification",
+            self.SALTSHAKER: "Downstream tool of mitosalt to classify and plot mito SVs",
             self.SENTION: "Sention algorithm",
             self.SOMALIER: "Tool for sample-swap and relatedness checks",
             self.SQUID: "Fusion caller",
@@ -678,9 +680,8 @@ class NalloTags(StrEnum):
 
 class RarediseaseTags(StrEnum):
     ANNOTATION: str = "annotation"
-    EKLIPSE_DEL: str = "eklipse-del"
-    EKLIPSE_GENES: str = "eklipse-gene"
-    EKLIPSE_PNG: str = "eklipse-png"
+    SALTSHAKER_CLASSIFY: str = "saltshaker-classify"
+    SALTSHAKER_PNG: str = "saltshaker-png"
     HAPLOGREP: str = "haplogrep"
     NGSBITS: str = "ngsbits-samplegender"
     SVDBQUERY: str = "svdbquery"
@@ -694,9 +695,8 @@ class RarediseaseTags(StrEnum):
     def description(self) -> str:
         descriptions: dict[str, RarediseaseTags] = {
             self.ANNOTATION: "Annotation tag",
-            self.EKLIPSE_DEL: "Mitochondrial eKLIPse deletions",
-            self.EKLIPSE_GENES: "Mitochondrial eKLIPse genes",
-            self.EKLIPSE_PNG: "Mitochondrial eKLIPse png",
+            self.SALTSHAKER_CLASSIFY: "Saltshaker classification for mitochondrial deletions",
+            self.SALTSHAKER_PNG: "Mitochondrial saltshaker png",
             self.HAPLOGREP: "Haplogrep",
             self.NGSBITS: "Result from SampleGender tool to determine sample sex",
             self.SVDBQUERY: "Query of SVDB results",

--- a/docs/raredisease_map.md
+++ b/docs/raredisease_map.md
@@ -1,68 +1,68 @@
-| Raredisease tags                                 | Mandatory   | HK tags                               | Used by                                        |
-|--------------------------------------------------|-------------|---------------------------------------|------------------------------------------------|
-| alignment, alignment_markduplicates              | False       | cram, picard-duplicates               | scout, clinical-delivery                       |
-| alignment_markduplicates_index, alignment        | False       | cram-index, picard-duplicates         | scout, clinical-delivery                       |
-| alignment, alignment_mt                          | False       | bam-mt                                | scout                                          |
-| alignment_mt_index, alignment                    | False       | bam-mt-index                          | scout                                          |
-| tiddit_coverage                                  | False       | tiddit-coverage, bigwig               | scout                                          |
-| d4tools_d4, qc_bam                               | False       | coverage, d4                          | scout                                          |
-| sambamba_depth, qc_bam                           | False       | coverage, sambamba_depth              | cg, long-term-storage                          |
-| tcov, chromograph_cov                            | False       | chromograph, tcov                     | scout                                          |
-| smncopynumbercaller, tsv                         | False       | smn-calling                           | scout, clinical-delivery, long-term-storage    |
-| variant_catalog, expansionhunter                 | False       | expansionhunter, variant-catalog      | scout, long-term-storage                       |
-| case_sv_str, expansionhunter_stranger            | False       | vcf-str                               | scout, long-term-storage, clinical-delivery    |
-| case_sv_str_index, expansionhunter_stranger      | False       | vcf-str-index                         | scout, long-term-storage, clinical-delivery    |
-| str_variants, expansionhunter                    | False       | expansionhunter, vcf-str              | scout                                          |
-| str_alignment, expansionhunter                   | False       | expansionhunter, bam                  | scout                                          |
-| str_alignment_index, expansionhunter             | False       | expansionhunter, bam-index            | scout                                          |
-| vcf2cytosure                                     | False       | vcf2cytosure                          | scout, long-term-storage                       |
-| baf, gens_generatedata                           | False       | gens, fracsnp, bed                    | scout                                          |
-| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index              | scout                                          |
-| gens_generatedata, cov                           | False       | gens, coverage, bed                   | scout                                          |
-| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index             | scout                                          |
-| call_mobile_elements                             | False       | mobile-elements, vcf                  | scout, long-term-storage                       |
-| call_mobile_elements, call_mobile_elements_index | False       | mobile-elements, vcf-index            | scout, long-term-storage                       |
-| clinical, annotate_mobile_elements               | False       | mobile-elements, clinical, vcf        | scout, clinical-delivery, long-term-storage    |
-| annotate_mobile_elements, clinical_index         | False       | mobile-elements, clinical, vcf-index  | scout, clinical-delivery, long-term-storage    |
-| research, annotate_mobile_elements               | False       | mobile-elements, research, vcf        | scout, clinical-delivery, long-term-storage    |
-| research_index, annotate_mobile_elements         | False       | mobile-elements, research, vcf-index  | scout, clinical-delivery, long-term-storage    |
-| call_snv                                         | True        | vcf-snv                               | genotype, clinical-delivery, long-term-storage |
-| call_snv_index, call_snv                         | False       | vcf-snv-index                         | cg, clinical-delivery, long-term-storage       |
-| call_snv_mt, call_snv                            | False       | vcf-snv, mitochondria                 | cg                                             |
-| call_snv, call_snv_mt_index                      | False       | vcf-snv-index, mitochondria           | cg                                             |
-| call_sv                                          | False       | vcf-sv                                | cg, clinical-delivery, long-term-storage       |
-| call_sv_index, call_sv                           | False       | vcf-sv-index                          | cg, clinical-delivery, long-term-storage       |
-| call_sv_mt_del, call_sv_mt                       | False       | mitochondria, mitodel                 | scout                                          |
-| saltshaker_classify, call_sv_mt                  | False       | saltshaker-classify, txt, mitochondria| scout, long-term-storage                              |
-| saltshaker_png, call_sv_mt                       | False       | saltshaker-png, mitochondria          | scout, long-term-storage                              |
-| snv_clinical, rank_and_filter                    | True        | vcf-snv-clinical                      | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, snv_clinical_index              | True        | vcf-snv-clinical-index                | scout, clinical-delivery, long-term-storage    |
-| snv_research, rank_and_filter                    | True        | vcf-snv-research                      | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, snv_research_index              | True        | vcf-snv-research-index                | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, sv_clinical                     | True        | vcf-sv-clinical                       | scout, clinical-delivery, long-term-storage    |
-| sv_clinical_index, rank_and_filter               | True        | vcf-sv-clinical-index                 | scout, clinical-delivery, long-term-storage    |
-| sv_research, rank_and_filter                     | True        | vcf-sv-research                       | scout, clinical-delivery, long-term-storage    |
-| sv_research_index, rank_and_filter               | True        | vcf-sv-research-index                 | scout, clinical-delivery, long-term-storage    |
-| mt_clinical, rank_and_filter                     | False       | vcf-sv-clinical, mitochondria         | scout, clinical-delivery, long-term-storage    |
-| mt_clinical_index, rank_and_filter               | False       | vcf-sv-clinical-index, mitochondria   | scout, clinical-delivery, long-term-storage    |
-| mt_research, rank_and_filter                     | False       | vcf-sv-research, mitochondria         | scout, clinical-delivery, long-term-storage    |
-| mt_research_index, rank_and_filter               | False       | vcf-sv-research-index, mitochondria   | scout, clinical-delivery, long-term-storage    |
-| ngsbits_samplegender                             | True        | ngsbits-samplegender                  | scout                                          |
-| peddy                                            | True        | peddy, ped                            | audit, scout, clinical-delivery                |
-| ped_check, peddy                                 | True        | peddy, ped-check                      | audit, scout, clinical-delivery                |
-| sex_check, peddy                                 | True        | peddy, sex-check                      | audit, scout, clinical-delivery                |
-| pedigree_fam, pedigree                           | True        | pedigree                              | scout                                          |
-| rhocallviz, annotate_snv                         | False       | rhocall-viz                           | scout                                          |
-| annotate_snv_mt, haplogrep                       | False       | haplogrep                             | scout, clinical-delivery                       |
-| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                  | scout                                          |
-| chromograph_upd, regions                         | False       | chromograph, upd, regions             | scout                                          |
-| chromograph_upd, sites                           | False       | chromograph, upd, sites               | scout                                          |
-| multiqc-html, multiqc                            | True        | multiqc-html                          | scout, clinical-delivery, long-term-storage    |
-| multiqc-json, multiqc                            | True        | multiqc-json                          | long-term-storage                              |
-| deepvariant, report                              | True        | deepvariant-report                    | clinical-delivery, long-term-storage           |
-| nextflow-params                                  | True        | nextflow-params                       | cg, long-term-storage                          |
-| nextflow-config                                  | True        | nextflow-config                       | cg, long-term-storage                          |
-| samplesheet                                      | True        | nextflow-samplesheet                  | cg, long-term-storage                          |
-| software-versions                                | True        | software-versions                     | cg, clinical-delivery, long-term-storage       |
-| qc-metrics                                       | True        | qc-metrics, deliverable               | cg, long-term-storage                          |
-| manifest                                         | False       | manifest                              | scout, long-term-storage                       |
+| Raredisease tags                                 | Mandatory   | HK tags                                | Used by                                        |
+|--------------------------------------------------|-------------|----------------------------------------|------------------------------------------------|
+| alignment, alignment_markduplicates              | False       | cram, picard-duplicates                | scout, clinical-delivery                       |
+| alignment_markduplicates_index, alignment        | False       | cram-index, picard-duplicates          | scout, clinical-delivery                       |
+| alignment, alignment_mt                          | False       | bam-mt                                 | scout                                          |
+| alignment_mt_index, alignment                    | False       | bam-mt-index                           | scout                                          |
+| tiddit_coverage                                  | False       | tiddit-coverage, bigwig                | scout                                          |
+| d4tools_d4, qc_bam                               | False       | coverage, d4                           | scout                                          |
+| sambamba_depth, qc_bam                           | False       | coverage, sambamba_depth               | cg, long-term-storage                          |
+| tcov, chromograph_cov                            | False       | chromograph, tcov                      | scout                                          |
+| smncopynumbercaller, tsv                         | False       | smn-calling                            | scout, clinical-delivery, long-term-storage    |
+| variant_catalog, expansionhunter                 | False       | expansionhunter, variant-catalog       | scout, long-term-storage                       |
+| case_sv_str, expansionhunter_stranger            | False       | vcf-str                                | scout, long-term-storage, clinical-delivery    |
+| case_sv_str_index, expansionhunter_stranger      | False       | vcf-str-index                          | scout, long-term-storage, clinical-delivery    |
+| str_variants, expansionhunter                    | False       | expansionhunter, vcf-str               | scout                                          |
+| str_alignment, expansionhunter                   | False       | expansionhunter, bam                   | scout                                          |
+| str_alignment_index, expansionhunter             | False       | expansionhunter, bam-index             | scout                                          |
+| vcf2cytosure                                     | False       | vcf2cytosure                           | scout, long-term-storage                       |
+| baf, gens_generatedata                           | False       | gens, fracsnp, bed                     | scout                                          |
+| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index               | scout                                          |
+| gens_generatedata, cov                           | False       | gens, coverage, bed                    | scout                                          |
+| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index              | scout                                          |
+| call_mobile_elements                             | False       | mobile-elements, vcf                   | scout, long-term-storage                       |
+| call_mobile_elements, call_mobile_elements_index | False       | mobile-elements, vcf-index             | scout, long-term-storage                       |
+| clinical, annotate_mobile_elements               | False       | mobile-elements, clinical, vcf         | scout, clinical-delivery, long-term-storage    |
+| annotate_mobile_elements, clinical_index         | False       | mobile-elements, clinical, vcf-index   | scout, clinical-delivery, long-term-storage    |
+| research, annotate_mobile_elements               | False       | mobile-elements, research, vcf         | scout, clinical-delivery, long-term-storage    |
+| research_index, annotate_mobile_elements         | False       | mobile-elements, research, vcf-index   | scout, clinical-delivery, long-term-storage    |
+| call_snv                                         | True        | vcf-snv                                | genotype, clinical-delivery, long-term-storage |
+| call_snv_index, call_snv                         | False       | vcf-snv-index                          | cg, clinical-delivery, long-term-storage       |
+| call_snv_mt, call_snv                            | False       | vcf-snv, mitochondria                  | cg                                             |
+| call_snv, call_snv_mt_index                      | False       | vcf-snv-index, mitochondria            | cg                                             |
+| call_sv                                          | False       | vcf-sv                                 | cg, clinical-delivery, long-term-storage       |
+| call_sv_index, call_sv                           | False       | vcf-sv-index                           | cg, clinical-delivery, long-term-storage       |
+| call_sv_mt_del, call_sv_mt                       | False       | mitochondria, mitodel                  | scout                                          |
+| saltshaker_classify, call_sv_mt                  | False       | saltshaker-classify, html, mitochondria| scout, long-term-storage                      |
+| saltshaker_png, call_sv_mt                       | False       | saltshaker-png, mitochondria           | scout, long-term-storage                       |
+| snv_clinical, rank_and_filter                    | True        | vcf-snv-clinical                       | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, snv_clinical_index              | True        | vcf-snv-clinical-index                 | scout, clinical-delivery, long-term-storage    |
+| snv_research, rank_and_filter                    | True        | vcf-snv-research                       | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, snv_research_index              | True        | vcf-snv-research-index                 | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, sv_clinical                     | True        | vcf-sv-clinical                        | scout, clinical-delivery, long-term-storage    |
+| sv_clinical_index, rank_and_filter               | True        | vcf-sv-clinical-index                  | scout, clinical-delivery, long-term-storage    |
+| sv_research, rank_and_filter                     | True        | vcf-sv-research                        | scout, clinical-delivery, long-term-storage    |
+| sv_research_index, rank_and_filter               | True        | vcf-sv-research-index                  | scout, clinical-delivery, long-term-storage    |
+| mt_clinical, rank_and_filter                     | False       | vcf-sv-clinical, mitochondria          | scout, clinical-delivery, long-term-storage    |
+| mt_clinical_index, rank_and_filter               | False       | vcf-sv-clinical-index, mitochondria    | scout, clinical-delivery, long-term-storage    |
+| mt_research, rank_and_filter                     | False       | vcf-sv-research, mitochondria          | scout, clinical-delivery, long-term-storage    |
+| mt_research_index, rank_and_filter               | False       | vcf-sv-research-index, mitochondria    | scout, clinical-delivery, long-term-storage    |
+| ngsbits_samplegender                             | True        | ngsbits-samplegender                   | scout                                          |
+| peddy                                            | True        | peddy, ped                             | audit, scout, clinical-delivery                |
+| ped_check, peddy                                 | True        | peddy, ped-check                       | audit, scout, clinical-delivery                |
+| sex_check, peddy                                 | True        | peddy, sex-check                       | audit, scout, clinical-delivery                |
+| pedigree_fam, pedigree                           | True        | pedigree                               | scout                                          |
+| rhocallviz, annotate_snv                         | False       | rhocall-viz                            | scout                                          |
+| annotate_snv_mt, haplogrep                       | False       | haplogrep                              | scout, clinical-delivery                       |
+| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                   | scout                                          |
+| chromograph_upd, regions                         | False       | chromograph, upd, regions              | scout                                          |
+| chromograph_upd, sites                           | False       | chromograph, upd, sites                | scout                                          |
+| multiqc-html, multiqc                            | True        | multiqc-html                           | scout, clinical-delivery, long-term-storage    |
+| multiqc-json, multiqc                            | True        | multiqc-json                           | long-term-storage                              |
+| deepvariant, report                              | True        | deepvariant-report                     | clinical-delivery, long-term-storage           |
+| nextflow-params                                  | True        | nextflow-params                        | cg, long-term-storage                          |
+| nextflow-config                                  | True        | nextflow-config                        | cg, long-term-storage                          |
+| samplesheet                                      | True        | nextflow-samplesheet                   | cg, long-term-storage                          |
+| software-versions                                | True        | software-versions                      | cg, clinical-delivery, long-term-storage       |
+| qc-metrics                                       | True        | qc-metrics, deliverable                | cg, long-term-storage                          |
+| manifest                                         | False       | manifest                               | scout, long-term-storage                       |

--- a/docs/raredisease_map.md
+++ b/docs/raredisease_map.md
@@ -1,71 +1,68 @@
-| Raredisease tags                                 | Mandatory   | HK tags                              | Used by                                        |
-|--------------------------------------------------|-------------|--------------------------------------|------------------------------------------------|
-| alignment, alignment_markduplicates              | False       | cram, picard-duplicates              | scout, clinical-delivery                       |
-| alignment_markduplicates_index, alignment        | False       | cram-index, picard-duplicates        | scout, clinical-delivery                       |
-| alignment, alignment_mt                          | False       | bam-mt                               | scout                                          |
-| alignment_mt_index, alignment                    | False       | bam-mt-index                         | scout                                          |
-| tiddit_coverage                                  | False       | tiddit-coverage, bigwig              | scout                                          |
-| d4tools_d4, qc_bam                              | False       | coverage, d4                         | scout                                          |
-| sambamba_depth, qc_bam                           | False       | coverage, sambamba_depth             | cg, long-term-storage                          |
-| tcov, chromograph_cov                            | False       | chromograph, tcov                    | scout                                          |
-| smncopynumbercaller, tsv                         | False       | smn-calling                          | scout, clinical-delivery, long-term-storage    |
-| variant_catalog, expansionhunter                 | False       | expansionhunter, variant-catalog     | scout, long-term-storage                       |
-| case_sv_str, expansionhunter_stranger            | False       | vcf-str                              | scout, long-term-storage, clinical-delivery    |
-| case_sv_str_index, expansionhunter_stranger      | False       | vcf-str-index                        | scout, long-term-storage, clinical-delivery    |
-| str_variants, expansionhunter                    | False       | expansionhunter, vcf-str             | scout                                          |
-| str_alignment, expansionhunter                   | False       | expansionhunter, bam                 | scout                                          |
-| str_alignment_index, expansionhunter             | False       | expansionhunter, bam-index           | scout                                          |
-| vcf2cytosure                                     | False       | vcf2cytosure                         | scout, long-term-storage                       |
-| baf, gens_generatedata                           | False       | gens, fracsnp, bed                   | scout                                          |
-| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index             | scout                                          |
-| gens_generatedata, cov                           | False       | gens, coverage, bed                  | scout                                          |
-| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index            | scout                                          |
-| call_mobile_elements                             | False       | mobile-elements, vcf                 | scout, long-term-storage                       |
-| call_mobile_elements, call_mobile_elements_index | False       | mobile-elements, vcf-index           | scout, long-term-storage                       |
-| clinical, annotate_mobile_elements               | False       | mobile-elements, clinical, vcf       | scout, clinical-delivery, long-term-storage    |
-| annotate_mobile_elements, clinical_index         | False       | mobile-elements, clinical, vcf-index | scout, clinical-delivery, long-term-storage    |
-| research, annotate_mobile_elements               | False       | mobile-elements, research, vcf       | scout, clinical-delivery, long-term-storage    |
-| research_index, annotate_mobile_elements         | False       | mobile-elements, research, vcf-index | scout, clinical-delivery, long-term-storage    |
-| call_snv                                         | True        | vcf-snv                              | genotype, clinical-delivery, long-term-storage |
-| call_snv_index, call_snv                         | False       | vcf-snv-index                        | cg, clinical-delivery, long-term-storage       |
-| call_snv_mt, call_snv                            | False       | vcf-snv, mitochondria                | cg                                             |
-| call_snv, call_snv_mt_index                      | False       | vcf-snv-index, mitochondria          | cg                                             |
-| call_sv                                          | False       | vcf-sv                               | cg, clinical-delivery, long-term-storage       |
-| call_sv_index, call_sv                           | False       | vcf-sv-index                         | cg, clinical-delivery, long-term-storage       |
-| call_sv_mt                                       | False       | vcf-sv, mitochondria                 | cg                                             |
-| call_sv_mt_index, call_sv_mt                     | False       | vcf-sv-index, mitochondria           | cg                                             |
-| call_sv_mt_del, call_sv_mt                       | False       | mitochondria, mitodel                | scout                                          |
-| eklipse_del, call_sv_mt                          | False       | eklipse-del, csv, mitochondria       | long-term-storage                              |
-| eklipse_png, call_sv_mt                          | False       | eklipse-png, mitochondria            | long-term-storage                              |
-| eklipse_genes, call_sv_mt                        | False       | eklipse-gene, csv, mitochondria      | scout                                          |
-| snv_clinical, rank_and_filter                    | True        | vcf-snv-clinical                     | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, snv_clinical_index              | True        | vcf-snv-clinical-index               | scout, clinical-delivery, long-term-storage    |
-| snv_research, rank_and_filter                    | True        | vcf-snv-research                     | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, snv_research_index              | True        | vcf-snv-research-index               | scout, clinical-delivery, long-term-storage    |
-| rank_and_filter, sv_clinical                     | True        | vcf-sv-clinical                      | scout, clinical-delivery, long-term-storage    |
-| sv_clinical_index, rank_and_filter               | True        | vcf-sv-clinical-index                | scout, clinical-delivery, long-term-storage    |
-| sv_research, rank_and_filter                     | True        | vcf-sv-research                      | scout, clinical-delivery, long-term-storage    |
-| sv_research_index, rank_and_filter               | True        | vcf-sv-research-index                | scout, clinical-delivery, long-term-storage    |
-| mt_clinical, rank_and_filter                     | False       | vcf-sv-clinical, mitochondria        | scout, clinical-delivery, long-term-storage    |
-| mt_clinical_index, rank_and_filter               | False       | vcf-sv-clinical-index, mitochondria  | scout, clinical-delivery, long-term-storage    |
-| mt_research, rank_and_filter                     | False       | vcf-sv-research, mitochondria        | scout, clinical-delivery, long-term-storage    |
-| mt_research_index, rank_and_filter               | False       | vcf-sv-research-index, mitochondria  | scout, clinical-delivery, long-term-storage    |
-| ngsbits_samplegender                             | True        | ngsbits-samplegender                 | scout                                          |
-| peddy                                            | True        | peddy, ped                           | audit, scout, clinical-delivery                |
-| ped_check, peddy                                 | True        | peddy, ped-check                     | audit, scout, clinical-delivery                |
-| sex_check, peddy                                 | True        | peddy, sex-check                     | audit, scout, clinical-delivery                |
-| pedigree_fam, pedigree                           | True        | pedigree                             | scout                                          |
-| rhocallviz, annotate_snv                         | False       | rhocall-viz                          | scout                                          |
-| annotate_snv_mt, haplogrep                       | False       | haplogrep                            | scout, clinical-delivery                       |
-| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                 | scout                                          |
-| chromograph_upd, regions                         | False       | chromograph, upd, regions            | scout                                          |
-| chromograph_upd, sites                           | False       | chromograph, upd, sites              | scout                                          |
-| multiqc-html, multiqc                            | True        | multiqc-html                         | scout, clinical-delivery, long-term-storage    |
-| multiqc-json, multiqc                            | True        | multiqc-json                         | long-term-storage                              |
-| deepvariant, report                              | True        | deepvariant-report                   | clinical-delivery, long-term-storage           |
-| nextflow-params                                  | True        | nextflow-params                      | cg, long-term-storage                          |
-| nextflow-config                                  | True        | nextflow-config                      | cg, long-term-storage                          |
-| samplesheet                                      | True        | nextflow-samplesheet                 | cg, long-term-storage                          |
-| software-versions                                | True        | software-versions                    | cg, clinical-delivery, long-term-storage       |
-| qc-metrics                                       | True        | qc-metrics, deliverable              | cg, long-term-storage                          |
-| manifest                                         | False       | manifest                             | scout, long-term-storage                       |
+| Raredisease tags                                 | Mandatory   | HK tags                               | Used by                                        |
+|--------------------------------------------------|-------------|---------------------------------------|------------------------------------------------|
+| alignment, alignment_markduplicates              | False       | cram, picard-duplicates               | scout, clinical-delivery                       |
+| alignment_markduplicates_index, alignment        | False       | cram-index, picard-duplicates         | scout, clinical-delivery                       |
+| alignment, alignment_mt                          | False       | bam-mt                                | scout                                          |
+| alignment_mt_index, alignment                    | False       | bam-mt-index                          | scout                                          |
+| tiddit_coverage                                  | False       | tiddit-coverage, bigwig               | scout                                          |
+| d4tools_d4, qc_bam                               | False       | coverage, d4                          | scout                                          |
+| sambamba_depth, qc_bam                           | False       | coverage, sambamba_depth              | cg, long-term-storage                          |
+| tcov, chromograph_cov                            | False       | chromograph, tcov                     | scout                                          |
+| smncopynumbercaller, tsv                         | False       | smn-calling                           | scout, clinical-delivery, long-term-storage    |
+| variant_catalog, expansionhunter                 | False       | expansionhunter, variant-catalog      | scout, long-term-storage                       |
+| case_sv_str, expansionhunter_stranger            | False       | vcf-str                               | scout, long-term-storage, clinical-delivery    |
+| case_sv_str_index, expansionhunter_stranger      | False       | vcf-str-index                         | scout, long-term-storage, clinical-delivery    |
+| str_variants, expansionhunter                    | False       | expansionhunter, vcf-str              | scout                                          |
+| str_alignment, expansionhunter                   | False       | expansionhunter, bam                  | scout                                          |
+| str_alignment_index, expansionhunter             | False       | expansionhunter, bam-index            | scout                                          |
+| vcf2cytosure                                     | False       | vcf2cytosure                          | scout, long-term-storage                       |
+| baf, gens_generatedata                           | False       | gens, fracsnp, bed                    | scout                                          |
+| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index              | scout                                          |
+| gens_generatedata, cov                           | False       | gens, coverage, bed                   | scout                                          |
+| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index             | scout                                          |
+| call_mobile_elements                             | False       | mobile-elements, vcf                  | scout, long-term-storage                       |
+| call_mobile_elements, call_mobile_elements_index | False       | mobile-elements, vcf-index            | scout, long-term-storage                       |
+| clinical, annotate_mobile_elements               | False       | mobile-elements, clinical, vcf        | scout, clinical-delivery, long-term-storage    |
+| annotate_mobile_elements, clinical_index         | False       | mobile-elements, clinical, vcf-index  | scout, clinical-delivery, long-term-storage    |
+| research, annotate_mobile_elements               | False       | mobile-elements, research, vcf        | scout, clinical-delivery, long-term-storage    |
+| research_index, annotate_mobile_elements         | False       | mobile-elements, research, vcf-index  | scout, clinical-delivery, long-term-storage    |
+| call_snv                                         | True        | vcf-snv                               | genotype, clinical-delivery, long-term-storage |
+| call_snv_index, call_snv                         | False       | vcf-snv-index                         | cg, clinical-delivery, long-term-storage       |
+| call_snv_mt, call_snv                            | False       | vcf-snv, mitochondria                 | cg                                             |
+| call_snv, call_snv_mt_index                      | False       | vcf-snv-index, mitochondria           | cg                                             |
+| call_sv                                          | False       | vcf-sv                                | cg, clinical-delivery, long-term-storage       |
+| call_sv_index, call_sv                           | False       | vcf-sv-index                          | cg, clinical-delivery, long-term-storage       |
+| call_sv_mt_del, call_sv_mt                       | False       | mitochondria, mitodel                 | scout                                          |
+| saltshaker_classify, call_sv_mt                  | False       | saltshaker-classify, txt, mitochondria| scout, long-term-storage                              |
+| saltshaker_png, call_sv_mt                       | False       | saltshaker-png, mitochondria          | scout, long-term-storage                              |
+| snv_clinical, rank_and_filter                    | True        | vcf-snv-clinical                      | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, snv_clinical_index              | True        | vcf-snv-clinical-index                | scout, clinical-delivery, long-term-storage    |
+| snv_research, rank_and_filter                    | True        | vcf-snv-research                      | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, snv_research_index              | True        | vcf-snv-research-index                | scout, clinical-delivery, long-term-storage    |
+| rank_and_filter, sv_clinical                     | True        | vcf-sv-clinical                       | scout, clinical-delivery, long-term-storage    |
+| sv_clinical_index, rank_and_filter               | True        | vcf-sv-clinical-index                 | scout, clinical-delivery, long-term-storage    |
+| sv_research, rank_and_filter                     | True        | vcf-sv-research                       | scout, clinical-delivery, long-term-storage    |
+| sv_research_index, rank_and_filter               | True        | vcf-sv-research-index                 | scout, clinical-delivery, long-term-storage    |
+| mt_clinical, rank_and_filter                     | False       | vcf-sv-clinical, mitochondria         | scout, clinical-delivery, long-term-storage    |
+| mt_clinical_index, rank_and_filter               | False       | vcf-sv-clinical-index, mitochondria   | scout, clinical-delivery, long-term-storage    |
+| mt_research, rank_and_filter                     | False       | vcf-sv-research, mitochondria         | scout, clinical-delivery, long-term-storage    |
+| mt_research_index, rank_and_filter               | False       | vcf-sv-research-index, mitochondria   | scout, clinical-delivery, long-term-storage    |
+| ngsbits_samplegender                             | True        | ngsbits-samplegender                  | scout                                          |
+| peddy                                            | True        | peddy, ped                            | audit, scout, clinical-delivery                |
+| ped_check, peddy                                 | True        | peddy, ped-check                      | audit, scout, clinical-delivery                |
+| sex_check, peddy                                 | True        | peddy, sex-check                      | audit, scout, clinical-delivery                |
+| pedigree_fam, pedigree                           | True        | pedigree                              | scout                                          |
+| rhocallviz, annotate_snv                         | False       | rhocall-viz                           | scout                                          |
+| annotate_snv_mt, haplogrep                       | False       | haplogrep                             | scout, clinical-delivery                       |
+| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                  | scout                                          |
+| chromograph_upd, regions                         | False       | chromograph, upd, regions             | scout                                          |
+| chromograph_upd, sites                           | False       | chromograph, upd, sites               | scout                                          |
+| multiqc-html, multiqc                            | True        | multiqc-html                          | scout, clinical-delivery, long-term-storage    |
+| multiqc-json, multiqc                            | True        | multiqc-json                          | long-term-storage                              |
+| deepvariant, report                              | True        | deepvariant-report                    | clinical-delivery, long-term-storage           |
+| nextflow-params                                  | True        | nextflow-params                       | cg, long-term-storage                          |
+| nextflow-config                                  | True        | nextflow-config                       | cg, long-term-storage                          |
+| samplesheet                                      | True        | nextflow-samplesheet                  | cg, long-term-storage                          |
+| software-versions                                | True        | software-versions                     | cg, clinical-delivery, long-term-storage       |
+| qc-metrics                                       | True        | qc-metrics, deliverable               | cg, long-term-storage                          |
+| manifest                                         | False       | manifest                              | scout, long-term-storage                       |

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -285,7 +285,7 @@ files:
   path: PATHTOCASE/call_sv/SAMPLEID_mitochondria_deletions.txt
   step: call_sv_mt
   tag: call_sv_mt_del
-- format: html
+- format: meta
   id: SAMPLEID
   path: PATHTOCASE/call_sv/SAMPLEID.saltshaker_classify.html
   step: call_sv_mt

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -285,9 +285,9 @@ files:
   path: PATHTOCASE/call_sv/SAMPLEID_mitochondria_deletions.txt
   step: call_sv_mt
   tag: call_sv_mt_del
-- format: csv
+- format: html
   id: SAMPLEID
-  path: PATHTOCASE/call_sv/SAMPLEID.saltshaker_classify.txt
+  path: PATHTOCASE/call_sv/SAMPLEID.saltshaker_classify.html
   step: call_sv_mt
   tag: saltshaker_classify
 - format: png

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -272,44 +272,29 @@ files:
   tag: call_snv_mt_index
 - format: vcf
   id: CASEID
-  path: PATHTOCASE/call_sv/genome/CASEID_sv.vcf.gz
+  path: PATHTOCASE/call_sv/CASEID_sv.vcf.gz
   step: call_sv
   tag: call_sv
 - format: vcf
   id: CASEID
-  path: PATHTOCASE/call_sv/genome/CASEID_sv.vcf.gz.tbi
+  path: PATHTOCASE/call_sv/CASEID_sv.vcf.gz.tbi
   step: call_sv
   tag: call_sv_index
-- format: vcf
-  id: CASEID
-  path: PATHTOCASE/call_snv/mitochondria/CASEID_mitochondria.vcf.gz
-  step: call_sv_mt
-  tag: call_sv_mt
-- format: vcf
-  id: CASEID
-  path: PATHTOCASE/call_snv/mitochondria/CASEID_mitochondria.vcf.gz.tbi
-  step: call_sv_mt
-  tag: call_sv_mt_index
 - format: meta
   id: SAMPLEID
-  path: PATHTOCASE/call_sv/mitochondria/SAMPLEID_mitochondria_deletions.txt
+  path: PATHTOCASE/call_sv/SAMPLEID_mitochondria_deletions.txt
   step: call_sv_mt
   tag: call_sv_mt_del
 - format: csv
   id: SAMPLEID
-  path: PATHTOCASE/call_sv/mitochondria/eKLIPse_SAMPLEID_deletions.csv
+  path: PATHTOCASE/call_sv/SAMPLEID.saltshaker_classify.txt
   step: call_sv_mt
-  tag: eklipse_del
+  tag: saltshaker_classify
 - format: png
   id: SAMPLEID
-  path: PATHTOCASE/call_sv/mitochondria/eKLIPse_SAMPLEID.png
+  path: PATHTOCASE/call_sv/SAMPLEID.saltshaker.png
   step: call_sv_mt
-  tag: eklipse_png
-- format: csv
-  id: SAMPLEID
-  path: PATHTOCASE/call_sv/mitochondria/eKLIPse_SAMPLEID_genes.csv
-  step: call_sv_mt
-  tag: eklipse_genes
+  tag: saltshaker_png
 - format: vcf
   id: CASEID
   path: PATHTOCASE/annotate_sv/CASEID_svdbquery_vep.vcf.gz


### PR DESCRIPTION
## Description
Update raredisease delivery to replace eklipse output with saltshaker output. Also combined nuclear and mitochondrial SV calling.

### Added

-

### Changed

- Removed call_sv_mt vcf output, since now all SV vcfs are combined.
- Also updated the path for all call_sv to reflect the combined calling.
- Changed ekplise output to saltshaker output (and removed the extra eklipse output for which there is no equivalent in saltshaker)

### Fixed

-

## Testing

### How to prepare for test

- [x] ssh to Hasta
- [x] Test your branch with

```bash
hermes-test-deploy <branch-name>
hermes-test <command here>
```

### How to test
- [ ] login to ...
- [x] do ... run a test case and then store files with hermes test deploy and corresponding servers branch (https://github.com/Clinical-Genomics/servers/pull/1850)

### Expected test result
- [x] check that ... saltshaker files are correctly delivered to housekeeper
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [x] tests executed by ID
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
