### PR TITLE
update saltshaker report to CASEID

### DIFF
--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -286,8 +286,8 @@ files:
   step: call_sv_mt
   tag: call_sv_mt_del
 - format: meta
-  id: SAMPLEID
-  path: PATHTOCASE/call_sv/SAMPLEID.saltshaker_classify.html
+  id: CASEID
+  path: PATHTOCASE/call_sv/CASEID.saltshaker_classify.html
   step: call_sv_mt
   tag: saltshaker_classify
 - format: png


### PR DESCRIPTION
## Description

This is part 2 of hermes changes that go with this servers PR which was merged a little while ago: https://github.com/Clinical-Genomics/servers/pull/1861. Hermes part 1 is here: https://github.com/Clinical-Genomics/hermes/pull/162.

### Added

-

### Changed

- Saltshaker html report is case level now instead of sample level.

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy <branch-name>
hermes-test <command here>
```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test result
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
