### PR TITLE
Nallo deliverables: Remove duplicate d4 file entry

### DIFF
--- a/cg_hermes/config/nallo.py
+++ b/cg_hermes/config/nallo.py
@@ -125,11 +125,6 @@ NALLO_COMMON_TAGS = {
         "is_mandatory": True,
         "used_by": [UsageTags.SCOUT, UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
-    frozenset(["qc_bam", "mosdepth_d4"]): {
-        "tags": [AnalysisTags.COVERAGE, ReportTags.D4],
-        "is_mandatory": False,
-        "used_by": [UsageTags.SCOUT, UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
-    },
     frozenset({"multiqc", "multiqc-html"}): {
         "is_mandatory": True,
         "tags": [ReportTags.MULTIQC_HTML],
@@ -337,7 +332,7 @@ NALLO_COMMON_TAGS = {
     },
     frozenset(["qc_bam", "mosdepth_d4"]): {
         "tags": [AnalysisTags.COVERAGE, ReportTags.D4],
-        "is_mandatory": True,
+        "is_mandatory": False,
         "used_by": [UsageTags.SCOUT, UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
     },
     frozenset(["copy_number", "bedgraph"]): {


### PR DESCRIPTION
## Description
Production reports and error while storing. The d4 file is no longer generated and should be an optional file. However, cg nallo store case fails. The problem is that the d4 file had a duplicate entry, one set to True and one to False.

### Added

-

### Changed

-

### Fixed

- Nallo: Removed duplicate d4 file entry

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy <branch-name>
hermes-test <command here>
```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test result
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
