### PR TITLE
Fix link for deliverables format in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ guidelines when contributing to Hermes.
 
 ## Deliverables Format
 
-Workflows must clearly define their deliverables in a [standardised format](https://atlas.scilifelab.se/infrastructure/dataflow/workflow/files_delivery/).
+Workflows must clearly define their deliverables in a [standardised format](https://atlas.scilifelab.se/infrastructure/data_management/dataflow/workflow/files_delivery/).
 
 ## Tags Format
 


### PR DESCRIPTION
## Description
Updated the link for the standardised format for deliverables.

### Added

-

### Changed

-

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy <branch-name>
hermes-test <command here>
```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test result
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
