### PR TITLE
Add rank model files for SNVs and SVs in deliverables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ guidelines when contributing to Hermes.
 
 ## Deliverables Format
 
-Workflows must clearly define their deliverables in a [standardised format](https://atlas.scilifelab.se/infrastructure/dataflow/workflow/files_delivery/).
+Workflows must clearly define their deliverables in a [standardised format](https://atlas.scilifelab.se/infrastructure/data_management/dataflow/workflow/files_delivery/).
 
 ## Tags Format
 

--- a/cg_hermes/config/nallo.py
+++ b/cg_hermes/config/nallo.py
@@ -10,6 +10,7 @@ from cg_hermes.constants.tags import (
     AnalysisTags,
     BioinfoToolsTags,
     FamilyTags,
+    InputFileTags,
     MipTags,
     NalloTags,
     NextflowTags,
@@ -399,6 +400,16 @@ NALLO_COMMON_TAGS = {
         "is_mandatory": True,
         "tags": [NextflowTags.SAMPLESHEET],
         "used_by": [UsageTags.CG, UsageTags.LONG_TERM_STORAGE],
+    },
+    frozenset({"rank-model-snv"}): {
+        "is_mandatory": True,
+        "tags": [InputFileTags.RANK_MODEL_SNV],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
+    },
+    frozenset({"rank-model-sv"}): {
+        "is_mandatory": True,
+        "tags": [InputFileTags.RANK_MODEL_SV],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
     },
 }
 

--- a/cg_hermes/config/raredisease.py
+++ b/cg_hermes/config/raredisease.py
@@ -10,13 +10,14 @@ from cg_hermes.constants.tags import (
     AnalysisTags,
     BioinfoToolsTags,
     FamilyTags,
+    InputFileTags,
     MipTags,
     NextflowTags,
     QCTags,
     RarediseaseTags,
     ReportTags,
-    VariantTags,
     UsageTags,
+    VariantTags,
 )
 
 RAREDISEASE_COMMON_TAGS = {
@@ -343,6 +344,16 @@ RAREDISEASE_COMMON_TAGS = {
         "tags": [ReportTags.DEEPVARIANT_REPORT],
         "is_mandatory": True,
         "used_by": [UsageTags.CLINICAL_DELIVERY, UsageTags.LONG_TERM_STORAGE],
+    },
+    frozenset({"rank-model-snv"}): {
+        "is_mandatory": True,
+        "tags": [InputFileTags.RANK_MODEL_SNV],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
+    },
+    frozenset({"rank-model-sv"}): {
+        "is_mandatory": True,
+        "tags": [InputFileTags.RANK_MODEL_SV],
+        "used_by": [UsageTags.SCOUT, UsageTags.LONG_TERM_STORAGE],
     },
 }
 

--- a/cg_hermes/constants/tags.py
+++ b/cg_hermes/constants/tags.py
@@ -522,6 +522,18 @@ class InputFileTags(StrEnum):
     RANK_MODEL_SNV = "rank-model-snv"
     RANK_MODEL_SV = "rank-model-sv"
 
+    @classmethod
+    def name(cls) -> str:
+        return "Input File Tags"
+
+    @property
+    def description(self) -> str:
+        descriptions: dict[InputFileTags, str] = {
+            self.RANK_MODEL_SNV: "Rank model for SNV prioritization",
+            self.RANK_MODEL_SV: "Rank model for SV prioritization",
+        }
+        return descriptions.get(self, "Description not available")
+
 
 class MipTags(StrEnum):
     EXE_VER: str = "exe-ver"

--- a/cg_hermes/constants/tags.py
+++ b/cg_hermes/constants/tags.py
@@ -518,6 +518,11 @@ class BioinfoToolsTags(StrEnum):
         return descriptions.get(self, "Description not available")
 
 
+class InputFileTags(StrEnum):
+    RANK_MODEL_SNV = "rank-model-snv"
+    RANK_MODEL_SV = "rank-model-sv"
+
+
 class MipTags(StrEnum):
     EXE_VER: str = "exe-ver"
     MIP_ANALYSE: str = "mip-analyse"
@@ -819,6 +824,7 @@ COMMON_TAG_CATEGORIES: list[Any] = [
     AnalysisTags,
     BioinfoToolsTags,
     FamilyTags,
+    InputFileTags,
     QCTags,
     RawDataTags,
     ReportTags,

--- a/docs/nallo_map.md
+++ b/docs/nallo_map.md
@@ -1,15 +1,15 @@
 | Nallo tags                                          | Mandatory   | HK tags                             | Used by                                     |
 |-----------------------------------------------------|-------------|-------------------------------------|---------------------------------------------|
-| alignment_haplotags, alignment                      | True        | bam, haplotags                      | scout, clinical-delivery, long-term-storage |
-| alignment_haplotags_index, alignment                | True        | bam-index, haplotags                | scout, clinical-delivery, long-term-storage |
+| alignment_haplotags, alignment                      | True        | cram, haplotags                     | scout, clinical-delivery, long-term-storage |
+| alignment_haplotags_index, alignment                | True        | cram-index, haplotags               | scout, clinical-delivery, long-term-storage |
 | assembly, summary_hap1                              | False       | hap1, assembly, assembly-summary    | clinical-delivery, long-term-storage        |
 | summary_hap2, assembly                              | False       | hap2, assembly, assembly-summary    | clinical-delivery, long-term-storage        |
-| assembly_aligned, assembly                          | False       | bam, assembly                       | clinical-delivery, long-term-storage        |
-| assembly, assembly_aligned_index                    | False       | bam-index, assembly                 | clinical-delivery, long-term-storage        |
-| baf, gens_generatedata                           | False       | gens, fracsnp, bed                   | scout                                          |
-| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index             | scout                                          |
-| cov, gens_generatedata                           | False       | gens, coverage, bed                  | scout                                          |
-| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index            | scout                                          |
+| assembly_aligned, assembly                          | False       | cram, assembly                      | clinical-delivery, long-term-storage        |
+| assembly, assembly_aligned_index                    | False       | cram-index, assembly                | clinical-delivery, long-term-storage        |
+| baf, gens_generatedata                           | False       | gens, fracsnp, bed                  | scout                                          |
+| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index            | scout                                          |
+| cov, gens_generatedata                           | False       | gens, coverage, bed                 | scout                                          |
+| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index           | scout                                          |
 | modkit_hap1, methylation_pileup                     | False       | bed, hap1, modkit-pileup            | clinical-delivery, long-term-storage        |
 | modkit_hap1_index, methylation_pileup               | False       | bed-index, hap1, modkit-pileup      | clinical-delivery, long-term-storage        |
 | modkit_hap2, methylation_pileup                     | False       | bed, hap2, modkit-pileup            | clinical-delivery, long-term-storage        |
@@ -33,18 +33,18 @@
 | ped_check, peddy                                    | True        | peddy, ped-check                    | audit, scout, clinical-delivery             |
 | peddy, sex_check                                    | True        | peddy, sex-check                    | audit, scout, clinical-delivery             |
 | deepvariant, report                                 | True        | deepvariant-report                  | clinical-delivery, long-term-storage        |
-| paraphase                                           | True        | bam, paraphase                      | clinical-delivery, long-term-storage        |
-| paraphase_index, paraphase                          | True        | bam-index, paraphase                | clinical-delivery, long-term-storage        |
+| paraphase                                           | True        | cram, paraphase                     | clinical-delivery, long-term-storage        |
+| paraphase_index, paraphase                          | True        | cram-index, paraphase               | clinical-delivery, long-term-storage        |
 | json, paraphase                                     | True        | paraphase, json                     | clinical-delivery, long-term-storage        |
-| json, paraphrase                                     | False        | paraphrase, json                     | clinical-delivery, long-term-storage        |
+| json, paraphrase                                     | False        | paraphrase, json                    | clinical-delivery, long-term-storage        |
 | tsv, paraphrase                                     | False        | paraphrase, tsv                     | clinical-delivery, long-term-storage        |
 | vcf, paraphase                                      | False       | paraphase, vcf                      | clinical-delivery, long-term-storage        |
 | vcf_index, paraphase                                | False       | paraphase, vcf-index                | clinical-delivery, long-term-storage        |
-| sambamba_depth                                      | True       | coverage, sambamba_depth             | cg, long-term-storage                          |
+| sambamba_depth                                      | True       | coverage, sambamba_depth            | cg, long-term-storage                          |
 | sorted_repeats, vcf_str                             | True        | repeats, sorted, vcf                | long-term-storage                           |
 | sorted_repeats, vcf_str_index                       | True        | repeats, sorted, vcf-index          | long-term-storage                           |
-| spanning_repeats, bam                               | True        | repeats, spanning, bam              | long-term-storage                           |
-| spanning_repeats, bam_index                         | True        | repeats, spanning, bam-index        | long-term-storage                           |
+| spanning_repeats, cram                               | True        | repeats, spanning, cram             | long-term-storage                           |
+| spanning_repeats, cram_index                         | True        | repeats, spanning, cram-index       | long-term-storage                           |
 | repeats_annotated, vcf_str                          | True        | vcf-str                             | scout, clinical-delivery, long-term-storage |
 | repeats_annotated, vcf_str_index                    | True        | vcf-str-index                       | scout, clinical-delivery, long-term-storage |
 | trgt, variant_catalog                               | True        | trgt, variant-catalog               | scout, long-term-storage                    |
@@ -76,5 +76,5 @@
 | whatshap, gtf                                       | True        | bam, paraphase                      | scout, clinical-delivery, long-term-storage |
 | whatshap, gtf_index                                 | True        | bam, paraphase                      | scout, clinical-delivery, long-term-storage |
 | manifest                                            | False       | manifest                            | scout, long-term-storage                    |
-| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                 | scout                                          |
-| tcov, chromograph_cov                            | False       | chromograph, tcov                    | scout
+| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                | scout                                          |
+| tcov, chromograph_cov                            | False       | chromograph, tcov                   | scout

--- a/docs/nallo_map.md
+++ b/docs/nallo_map.md
@@ -1,82 +1,83 @@
-| Nallo tags                                          | Mandatory   | HK tags                            | Used by                                     |
-|-----------------------------------------------------|-------------|------------------------------------|---------------------------------------------|
-| alignment_haplotags, alignment                      | True        | cram, haplotags                    | scout, clinical-delivery, long-term-storage |
-| alignment_haplotags_index, alignment                | True        | cram-index, haplotags              | scout, clinical-delivery, long-term-storage |
-| assembly, summary_hap1                              | False       | hap1, assembly, assembly-summary   | clinical-delivery, long-term-storage        |
-| summary_hap2, assembly                              | False       | hap2, assembly, assembly-summary   | clinical-delivery, long-term-storage        |
-| assembly_aligned, assembly                          | False       | cram, assembly                     | clinical-delivery, long-term-storage        |
-| assembly, assembly_aligned_index                    | False       | cram-index, assembly               | clinical-delivery, long-term-storage        |
-| baf, gens_generatedata                              | False       | gens, fracsnp, bed                 | scout                                          |
-| baf_index, gens_generatedata                        | False       | gens, fracsnp, bed-index           | scout                                          |
-| cov, gens_generatedata                              | False       | gens, coverage, bed                | scout                                          |
-| cov_index, gens_generatedata                        | False       | gens, coverage, bed-index          | scout                                          |
-| modkit_hap1, methylation_pileup                     | False       | bed, hap1, modkit-pileup           | clinical-delivery, long-term-storage        |
-| modkit_hap1_index, methylation_pileup               | False       | bed-index, hap1, modkit-pileup     | clinical-delivery, long-term-storage        |
-| modkit_hap2, methylation_pileup                     | False       | bed, hap2, modkit-pileup           | clinical-delivery, long-term-storage        |
-| modkit_hap2_index, methylation_pileup               | False       | bed-index, hap2, modkit-pileup     | clinical-delivery, long-term-storage        |
-| modkit_ungrouped, methylation_pileup                | False       | bed, ungrouped, modkit-pileup      | clinical-delivery, long-term-storage        |
-| modkit_ungrouped_index, methylation_pileup          | False       | bed-index, ungrouped, modkit-pileup | clinical-delivery, long-term-storage        |
-| methbat_hap1, methylation_pileup                    | True        | bed, hap1, methbat-pileup          | clinical-delivery, long-term-storage        |
-| methbat_hap1_index, methylation_pileup              | True        | bed-index, hap1, methbat-pileup    | clinical-delivery, long-term-storage        |
-| methbat_hap2, methylation_pileup                    | True        | bed, hap2, methbat-pileup          | clinical-delivery, long-term-storage        |
-| methbat_hap2_index, methylation_pileup              | True        | bed-index, hap2, methbat-pileup    | clinical-delivery, long-term-storage        |
-| methbat_combined, methylation_pileup                | True        | bed, combined, methbat-pileup      | clinical-delivery, long-term-storage        |
-| methbat_combined_index, methylation_pileup          | True        | bed-index, combined, modkit-pileup | clinical-delivery, long-term-storage        |
-| methbat_profile, methylation_calling                | True        | methylation-tsv, methbat-profile   | scout, clinical-delivery, long-term-storage |
-| mosdepth_d4, qc_bam                                 | False        | coverage, d4                       | scout, clinical-delivery, long-term-storage |
-| multiqc-html, multiqc                               | True        | multiqc-html                       | scout, clinical-delivery, long-term-storage |
-| pedigree_fam, pedigree                              | True        | pedigree                           | clinical-delivery, scout, long-term-storage |
-| relate_html, somalier                               | True        | somalier, relate-html              | clinical-delivery, scout, long-term-storage |
-| relate_pairs, somalier                              | True        | somalier, relate-pairs             | scout, long-term-storage                    |
-| relate_samples, somalier                            | True        | somalier, relate-samples           | scout, long-term-storage                    |
-| peddy                                               | True        | peddy, ped                         | audit, scout, clinical-delivery             |
-| ped_check, peddy                                    | True        | peddy, ped-check                   | audit, scout, clinical-delivery             |
-| peddy, sex_check                                    | True        | peddy, sex-check                   | audit, scout, clinical-delivery             |
-| deepvariant, report                                 | True        | deepvariant-report                 | clinical-delivery, long-term-storage        |
-| paraphase                                           | True        | cram, paraphase                    | clinical-delivery, long-term-storage        |
-| paraphase_index, paraphase                          | True        | cram-index, paraphase              | clinical-delivery, long-term-storage        |
-| json, paraphase                                     | True        | paraphase, json                    | clinical-delivery, long-term-storage        |
-| json, paraphrase                                    | False        | paraphrase, json                   | clinical-delivery, long-term-storage        |
-| tsv, paraphrase                                     | False        | paraphrase, tsv                    | clinical-delivery, long-term-storage        |
-| vcf, paraphase                                      | False       | paraphase, vcf                     | clinical-delivery, long-term-storage        |
-| vcf_index, paraphase                                | False       | paraphase, vcf-index               | clinical-delivery, long-term-storage        |
-| sambamba_depth                                      | True       | coverage, sambamba_depth           | cg, long-term-storage                          |
-| sorted_repeats, vcf_str                             | True        | repeats, sorted, vcf               | long-term-storage                           |
-| sorted_repeats, vcf_str_index                       | True        | repeats, sorted, vcf-index         | long-term-storage                           |
-| spanning_repeats, cram                              | True        | repeats, spanning, cram            | long-term-storage                           |
-| spanning_repeats, cram_index                        | True        | repeats, spanning, cram-index      | long-term-storage                           |
-| rank-model-snv                                      | True        | rank-model-snv                     | scout, long-term-storage                    |
-| repeats_annotated, vcf_str                          | True        | vcf-str                            | scout, clinical-delivery, long-term-storage |
-| repeats_annotated, vcf_str                          | True        | vcf-str                            | scout, clinical-delivery, long-term-storage |
-| repeats_annotated, vcf_str_index                    | True        | vcf-str-index                      | scout, clinical-delivery, long-term-storage |
-| trgt, variant_catalog                               | True        | trgt, variant-catalog              | scout, long-term-storage                    |
-| vcf_snv_research, snv_annotated                     | True        | vcf-snv-research                   | scout, clinical-delivery, long-term-storage |
-| vcf_snv_research_index, snv_annotated               | True        | vcf-snv-research-index             | scout, clinical-delivery, long-term-storage |
-| vcf_snv_clinical, snv_annotated_filtered            | True        | vcf-snv-clinical                   | scout, clinical-delivery, long-term-storage |
-| vcf_snv_clinical_index, snv_annotated_filtered      | True        | vcf-snv-clinical-index             | scout, clinical-delivery, long-term-storage |
-| vcf_sv_research, sv_annotated_ranked                | True        | vcf-sv-research                    | scout, clinical-delivery, long-term-storage |
-| vcf_sv_research_index, sv_annotated_ranked          | True        | vcf-sv-research-index              | scout, clinical-delivery, long-term-storage |
-| vcf_sv_clinical, sv_annotated_ranked_filtered       | True        | vcf-sv-clinical                    | scout, clinical-delivery, long-term-storage |
-| vcf_sv_clinical_index, sv_annotated_ranked_filtered | True        | vcf-sv-clinical-index              | scout, clinical-delivery, long-term-storage |
-| svs_per_caller, vcf_hificnv                         | True        | hificnv, vcf                       | long-term-storage                           |
-| svs_per_caller, vcf_hificnv_index                   | True        | hificnv, vcf-index                 | long-term-storage                           |
-| svs_per_caller, vcf_sawfish                         | True        | sawfish, vcf                       | long-term-storage                           |
-| svs_per_caller, vcf_sawfish_index                   | True        | sawfish, vcf-index                 | long-term-storage                           |
-| svs_per_caller, vcf_severus                         | True        | severus, vcf                       | long-term-storage                           |
-| svs_per_caller, vcf_severus_index                   | True        | severus, vcf-index                 | long-term-storage                           |
-| svs_per_caller, vcf_sniffles                        | True        | sniffles1, vcf                     | long-term-storage                           |
-| svs_per_caller, vcf_sniffles_index                  | True        | sniffles1, vcf-index               | long-term-storage                           |
-| copy_number, bedgraph                               | True        | cnv, bedgraph                      | clinical-delivery, long-term-storage        |
-| depth_track, bigwig                                 | True        | hificnv, bigwig                    | clinical-delivery, long-term-storage        |
-| maf_depth_track, bigwig                             | True        | hificnv, bigwig, maf               | clinical-delivery, long-term-storage        |
-| multiqc-json, multiqc                               | True        | multiqc-json                       | long-term-storage                           |
-| nextflow-params                                     | True        | nextflow-params                    | cg, long-term-storage                       |
-| nextflow-config                                     | True        | nextflow-config                    | cg, long-term-storage                       |
-| samplesheet                                         | True        | nextflow-samplesheet               | cg, long-term-storage                       |
-| software-versions                                   | True        | software-versions                  | cg, clinical-delivery, long-term-storage    |
-| qc-metrics                                          | True        | qc-metrics, deliverable            | cg, long-term-storage                       |
-| whatshap, gtf                                       | True        | bam, paraphase                     | scout, clinical-delivery, long-term-storage |
-| whatshap, gtf_index                                 | True        | bam, paraphase                     | scout, clinical-delivery, long-term-storage |
-| manifest                                            | False       | manifest                           | scout, long-term-storage                    |
-| chromograph_rhoviz, autozyg                         | False       | chromograph, autozyg               | scout                                          |
-| tcov, chromograph_cov                               | False       | chromograph, tcov                  | scout
+| Nallo tags                                         | Mandatory   | HK tags                           | Used by                                     |
+|----------------------------------------------------|-------------|-----------------------------------|---------------------------------------------|
+| alignment_haplotags, alignment                     | True        | cram, haplotags                   | scout, clinical-delivery, long-term-storage |
+| alignment_haplotags_index, alignment               | True        | cram-index, haplotags             | scout, clinical-delivery, long-term-storage |
+| assembly, summary_hap1                             | False       | hap1, assembly, assembly-summary  | clinical-delivery, long-term-storage        |
+| summary_hap2, assembly                             | False       | hap2, assembly, assembly-summary  | clinical-delivery, long-term-storage        |
+| assembly_aligned, assembly                         | False       | cram, assembly                    | clinical-delivery, long-term-storage        |
+| assembly, assembly_aligned_index                   | False       | cram-index, assembly              | clinical-delivery, long-term-storage        |
+| baf, gens_generatedata                             | False       | gens, fracsnp, bed                | scout                                          |
+| baf_index, gens_generatedata                       | False       | gens, fracsnp, bed-index          | scout                                          |
+| cov, gens_generatedata                             | False       | gens, coverage, bed               | scout                                          |
+| cov_index, gens_generatedata                       | False       | gens, coverage, bed-index         | scout                                          |
+| modkit_hap1, methylation_pileup                    | False       | bed, hap1, modkit-pileup          | clinical-delivery, long-term-storage        |
+| modkit_hap1_index, methylation_pileup              | False       | bed-index, hap1, modkit-pileup    | clinical-delivery, long-term-storage        |
+| modkit_hap2, methylation_pileup                    | False       | bed, hap2, modkit-pileup          | clinical-delivery, long-term-storage        |
+| modkit_hap2_index, methylation_pileup              | False       | bed-index, hap2, modkit-pileup    | clinical-delivery, long-term-storage        |
+| modkit_ungrouped, methylation_pileup               | False       | bed, ungrouped, modkit-pileup     | clinical-delivery, long-term-storage        |
+| modkit_ungrouped_index, methylation_pileup         | False       | bed-index, ungrouped, modkit-pileup | clinical-delivery, long-term-storage        |
+| methbat_hap1, methylation_pileup                   | True        | bed, hap1, methbat-pileup         | clinical-delivery, long-term-storage        |
+| methbat_hap1_index, methylation_pileup             | True        | bed-index, hap1, methbat-pileup   | clinical-delivery, long-term-storage        |
+| methbat_hap2, methylation_pileup                   | True        | bed, hap2, methbat-pileup         | clinical-delivery, long-term-storage        |
+| methbat_hap2_index, methylation_pileup             | True        | bed-index, hap2, methbat-pileup   | clinical-delivery, long-term-storage        |
+| methbat_combined, methylation_pileup               | True        | bed, combined, methbat-pileup     | clinical-delivery, long-term-storage        |
+| methbat_combined_index, methylation_pileup         | True        | bed-index, combined, modkit-pileup | clinical-delivery, long-term-storage        |
+| methbat_profile, methylation_calling               | True        | methylation-tsv, methbat-profile  | scout, clinical-delivery, long-term-storage |
+| mosdepth_d4, qc_bam                                | False        | coverage, d4                      | scout, clinical-delivery, long-term-storage |
+| multiqc-html, multiqc                              | True        | multiqc-html                      | scout, clinical-delivery, long-term-storage |
+| pedigree_fam, pedigree                             | True        | pedigree                          | clinical-delivery, scout, long-term-storage |
+| relate_html, somalier                              | True        | somalier, relate-html             | clinical-delivery, scout, long-term-storage |
+| relate_pairs, somalier                             | True        | somalier, relate-pairs            | scout, long-term-storage                    |
+| relate_samples, somalier                           | True        | somalier, relate-samples          | scout, long-term-storage                    |
+| peddy                                              | True        | peddy, ped                        | audit, scout, clinical-delivery             |
+| ped_check, peddy                                   | True        | peddy, ped-check                  | audit, scout, clinical-delivery             |
+| peddy, sex_check                                   | True        | peddy, sex-check                  | audit, scout, clinical-delivery             |
+| deepvariant, report                                | True        | deepvariant-report                | clinical-delivery, long-term-storage        |
+| paraphase                                          | True        | cram, paraphase                   | clinical-delivery, long-term-storage        |
+| paraphase_index, paraphase                         | True        | cram-index, paraphase             | clinical-delivery, long-term-storage        |
+| json, paraphase                                    | True        | paraphase, json                   | clinical-delivery, long-term-storage        |
+| json, paraphrase                                   | False        | paraphrase, json                  | clinical-delivery, long-term-storage        |
+| tsv, paraphrase                                    | False        | paraphrase, tsv                   | clinical-delivery, long-term-storage        |
+| vcf, paraphase                                     | False       | paraphase, vcf                    | clinical-delivery, long-term-storage        |
+| vcf_index, paraphase                               | False       | paraphase, vcf-index              | clinical-delivery, long-term-storage        |
+| sambamba_depth                                     | True       | coverage, sambamba_depth          | cg, long-term-storage                          |
+| sorted_repeats, vcf_str                            | True        | repeats, sorted, vcf              | long-term-storage                           |
+| sorted_repeats, vcf_str_index                      | True        | repeats, sorted, vcf-index        | long-term-storage                           |
+| spanning_repeats, cram                             | True        | repeats, spanning, cram           | long-term-storage                           |
+| spanning_repeats, cram_index                       | True        | repeats, spanning, cram-index     | long-term-storage                           |
+| rank-model-snv                                     | True        | rank-model-snv                    | scout, long-term-storage                    |
+| rank-model-sv                                      | True        | rank-model-sv                     | scout, long-term-storage                    |
+| repeats_annotated, vcf_str                         | True        | vcf-str                           | scout, clinical-delivery, long-term-storage |
+| repeats_annotated, vcf_str                         | True        | vcf-str                           | scout, clinical-delivery, long-term-storage |
+| repeats_annotated, vcf_str_index                   | True        | vcf-str-index                     | scout, clinical-delivery, long-term-storage |
+| trgt, variant_catalog                              | True        | trgt, variant-catalog             | scout, long-term-storage                    |
+| vcf_snv_research, snv_annotated                    | True        | vcf-snv-research                  | scout, clinical-delivery, long-term-storage |
+| vcf_snv_research_index, snv_annotated              | True        | vcf-snv-research-index            | scout, clinical-delivery, long-term-storage |
+| vcf_snv_clinical, snv_annotated_filtered           | True        | vcf-snv-clinical                  | scout, clinical-delivery, long-term-storage |
+| vcf_snv_clinical_index, snv_annotated_filtered     | True        | vcf-snv-clinical-index            | scout, clinical-delivery, long-term-storage |
+| vcf_sv_research, sv_annotated_ranked               | True        | vcf-sv-research                   | scout, clinical-delivery, long-term-storage |
+| vcf_sv_research_index, sv_annotated_ranked         | True        | vcf-sv-research-index             | scout, clinical-delivery, long-term-storage |
+| vcf_sv_clinical, sv_annotated_ranked_filtered      | True        | vcf-sv-clinical                   | scout, clinical-delivery, long-term-storage |
+| vcf_sv_clinical_index, sv_annotated_ranked_filtered | True        | vcf-sv-clinical-index             | scout, clinical-delivery, long-term-storage |
+| svs_per_caller, vcf_hificnv                        | True        | hificnv, vcf                      | long-term-storage                           |
+| svs_per_caller, vcf_hificnv_index                  | True        | hificnv, vcf-index                | long-term-storage                           |
+| svs_per_caller, vcf_sawfish                        | True        | sawfish, vcf                      | long-term-storage                           |
+| svs_per_caller, vcf_sawfish_index                  | True        | sawfish, vcf-index                | long-term-storage                           |
+| svs_per_caller, vcf_severus                        | True        | severus, vcf                      | long-term-storage                           |
+| svs_per_caller, vcf_severus_index                  | True        | severus, vcf-index                | long-term-storage                           |
+| svs_per_caller, vcf_sniffles                       | True        | sniffles1, vcf                    | long-term-storage                           |
+| svs_per_caller, vcf_sniffles_index                 | True        | sniffles1, vcf-index              | long-term-storage                           |
+| copy_number, bedgraph                              | True        | cnv, bedgraph                     | clinical-delivery, long-term-storage        |
+| depth_track, bigwig                                | True        | hificnv, bigwig                   | clinical-delivery, long-term-storage        |
+| maf_depth_track, bigwig                            | True        | hificnv, bigwig, maf              | clinical-delivery, long-term-storage        |
+| multiqc-json, multiqc                              | True        | multiqc-json                      | long-term-storage                           |
+| nextflow-params                                    | True        | nextflow-params                   | cg, long-term-storage                       |
+| nextflow-config                                    | True        | nextflow-config                   | cg, long-term-storage                       |
+| samplesheet                                        | True        | nextflow-samplesheet              | cg, long-term-storage                       |
+| software-versions                                  | True        | software-versions                 | cg, clinical-delivery, long-term-storage    |
+| qc-metrics                                         | True        | qc-metrics, deliverable           | cg, long-term-storage                       |
+| whatshap, gtf                                      | True        | bam, paraphase                    | scout, clinical-delivery, long-term-storage |
+| whatshap, gtf_index                                | True        | bam, paraphase                    | scout, clinical-delivery, long-term-storage |
+| manifest                                           | False       | manifest                          | scout, long-term-storage                    |
+| chromograph_rhoviz, autozyg                        | False       | chromograph, autozyg              | scout                                          |
+| tcov, chromograph_cov                              | False       | chromograph, tcov                 | scout

--- a/docs/nallo_map.md
+++ b/docs/nallo_map.md
@@ -1,80 +1,82 @@
-| Nallo tags                                          | Mandatory   | HK tags                             | Used by                                     |
-|-----------------------------------------------------|-------------|-------------------------------------|---------------------------------------------|
-| alignment_haplotags, alignment                      | True        | cram, haplotags                     | scout, clinical-delivery, long-term-storage |
-| alignment_haplotags_index, alignment                | True        | cram-index, haplotags               | scout, clinical-delivery, long-term-storage |
-| assembly, summary_hap1                              | False       | hap1, assembly, assembly-summary    | clinical-delivery, long-term-storage        |
-| summary_hap2, assembly                              | False       | hap2, assembly, assembly-summary    | clinical-delivery, long-term-storage        |
-| assembly_aligned, assembly                          | False       | cram, assembly                      | clinical-delivery, long-term-storage        |
-| assembly, assembly_aligned_index                    | False       | cram-index, assembly                | clinical-delivery, long-term-storage        |
-| baf, gens_generatedata                           | False       | gens, fracsnp, bed                  | scout                                          |
-| baf_index, gens_generatedata                     | False       | gens, fracsnp, bed-index            | scout                                          |
-| cov, gens_generatedata                           | False       | gens, coverage, bed                 | scout                                          |
-| cov_index, gens_generatedata                     | False       | gens, coverage, bed-index           | scout                                          |
-| modkit_hap1, methylation_pileup                     | False       | bed, hap1, modkit-pileup            | clinical-delivery, long-term-storage        |
-| modkit_hap1_index, methylation_pileup               | False       | bed-index, hap1, modkit-pileup      | clinical-delivery, long-term-storage        |
-| modkit_hap2, methylation_pileup                     | False       | bed, hap2, modkit-pileup            | clinical-delivery, long-term-storage        |
-| modkit_hap2_index, methylation_pileup               | False       | bed-index, hap2, modkit-pileup      | clinical-delivery, long-term-storage        |
-| modkit_ungrouped, methylation_pileup                | False       | bed, ungrouped, modkit-pileup       | clinical-delivery, long-term-storage        |
+| Nallo tags                                          | Mandatory   | HK tags                            | Used by                                     |
+|-----------------------------------------------------|-------------|------------------------------------|---------------------------------------------|
+| alignment_haplotags, alignment                      | True        | cram, haplotags                    | scout, clinical-delivery, long-term-storage |
+| alignment_haplotags_index, alignment                | True        | cram-index, haplotags              | scout, clinical-delivery, long-term-storage |
+| assembly, summary_hap1                              | False       | hap1, assembly, assembly-summary   | clinical-delivery, long-term-storage        |
+| summary_hap2, assembly                              | False       | hap2, assembly, assembly-summary   | clinical-delivery, long-term-storage        |
+| assembly_aligned, assembly                          | False       | cram, assembly                     | clinical-delivery, long-term-storage        |
+| assembly, assembly_aligned_index                    | False       | cram-index, assembly               | clinical-delivery, long-term-storage        |
+| baf, gens_generatedata                              | False       | gens, fracsnp, bed                 | scout                                          |
+| baf_index, gens_generatedata                        | False       | gens, fracsnp, bed-index           | scout                                          |
+| cov, gens_generatedata                              | False       | gens, coverage, bed                | scout                                          |
+| cov_index, gens_generatedata                        | False       | gens, coverage, bed-index          | scout                                          |
+| modkit_hap1, methylation_pileup                     | False       | bed, hap1, modkit-pileup           | clinical-delivery, long-term-storage        |
+| modkit_hap1_index, methylation_pileup               | False       | bed-index, hap1, modkit-pileup     | clinical-delivery, long-term-storage        |
+| modkit_hap2, methylation_pileup                     | False       | bed, hap2, modkit-pileup           | clinical-delivery, long-term-storage        |
+| modkit_hap2_index, methylation_pileup               | False       | bed-index, hap2, modkit-pileup     | clinical-delivery, long-term-storage        |
+| modkit_ungrouped, methylation_pileup                | False       | bed, ungrouped, modkit-pileup      | clinical-delivery, long-term-storage        |
 | modkit_ungrouped_index, methylation_pileup          | False       | bed-index, ungrouped, modkit-pileup | clinical-delivery, long-term-storage        |
-| methbat_hap1, methylation_pileup                    | True        | bed, hap1, methbat-pileup           | clinical-delivery, long-term-storage        |
-| methbat_hap1_index, methylation_pileup              | True        | bed-index, hap1, methbat-pileup     | clinical-delivery, long-term-storage        |
-| methbat_hap2, methylation_pileup                    | True        | bed, hap2, methbat-pileup           | clinical-delivery, long-term-storage        |
-| methbat_hap2_index, methylation_pileup              | True        | bed-index, hap2, methbat-pileup     | clinical-delivery, long-term-storage        |
-| methbat_combined, methylation_pileup                | True        | bed, combined, methbat-pileup       | clinical-delivery, long-term-storage        |
-| methbat_combined_index, methylation_pileup          | True        | bed-index, combined, modkit-pileup  | clinical-delivery, long-term-storage        |
-| methbat_profile, methylation_calling                | True        | methylation-tsv, methbat-profile    | scout, clinical-delivery, long-term-storage |
-| mosdepth_d4, qc_bam                                 | False        | coverage, d4                        | scout, clinical-delivery, long-term-storage |
-| multiqc-html, multiqc                               | True        | multiqc-html                        | scout, clinical-delivery, long-term-storage |
-| pedigree_fam, pedigree                              | True        | pedigree                            | clinical-delivery, scout, long-term-storage |
-| relate_html, somalier                               | True        | somalier, relate-html               | clinical-delivery, scout, long-term-storage |
-| relate_pairs, somalier                              | True        | somalier, relate-pairs              | scout, long-term-storage                    |
-| relate_samples, somalier                            | True        | somalier, relate-samples            | scout, long-term-storage                    |
-| peddy                                               | True        | peddy, ped                          | audit, scout, clinical-delivery             |
-| ped_check, peddy                                    | True        | peddy, ped-check                    | audit, scout, clinical-delivery             |
-| peddy, sex_check                                    | True        | peddy, sex-check                    | audit, scout, clinical-delivery             |
-| deepvariant, report                                 | True        | deepvariant-report                  | clinical-delivery, long-term-storage        |
-| paraphase                                           | True        | cram, paraphase                     | clinical-delivery, long-term-storage        |
-| paraphase_index, paraphase                          | True        | cram-index, paraphase               | clinical-delivery, long-term-storage        |
-| json, paraphase                                     | True        | paraphase, json                     | clinical-delivery, long-term-storage        |
-| json, paraphrase                                     | False        | paraphrase, json                    | clinical-delivery, long-term-storage        |
-| tsv, paraphrase                                     | False        | paraphrase, tsv                     | clinical-delivery, long-term-storage        |
-| vcf, paraphase                                      | False       | paraphase, vcf                      | clinical-delivery, long-term-storage        |
-| vcf_index, paraphase                                | False       | paraphase, vcf-index                | clinical-delivery, long-term-storage        |
-| sambamba_depth                                      | True       | coverage, sambamba_depth            | cg, long-term-storage                          |
-| sorted_repeats, vcf_str                             | True        | repeats, sorted, vcf                | long-term-storage                           |
-| sorted_repeats, vcf_str_index                       | True        | repeats, sorted, vcf-index          | long-term-storage                           |
-| spanning_repeats, cram                               | True        | repeats, spanning, cram             | long-term-storage                           |
-| spanning_repeats, cram_index                         | True        | repeats, spanning, cram-index       | long-term-storage                           |
-| repeats_annotated, vcf_str                          | True        | vcf-str                             | scout, clinical-delivery, long-term-storage |
-| repeats_annotated, vcf_str_index                    | True        | vcf-str-index                       | scout, clinical-delivery, long-term-storage |
-| trgt, variant_catalog                               | True        | trgt, variant-catalog               | scout, long-term-storage                    |
-| vcf_snv_research, snv_annotated                     | True        | vcf-snv-research                    | scout, clinical-delivery, long-term-storage |
-| vcf_snv_research_index, snv_annotated               | True        | vcf-snv-research-index              | scout, clinical-delivery, long-term-storage |
-| vcf_snv_clinical, snv_annotated_filtered            | True        | vcf-snv-clinical                    | scout, clinical-delivery, long-term-storage |
-| vcf_snv_clinical_index, snv_annotated_filtered      | True        | vcf-snv-clinical-index              | scout, clinical-delivery, long-term-storage |
-| vcf_sv_research, sv_annotated_ranked                | True        | vcf-sv-research                     | scout, clinical-delivery, long-term-storage |
-| vcf_sv_research_index, sv_annotated_ranked          | True        | vcf-sv-research-index               | scout, clinical-delivery, long-term-storage |
-| vcf_sv_clinical, sv_annotated_ranked_filtered       | True        | vcf-sv-clinical                     | scout, clinical-delivery, long-term-storage |
-| vcf_sv_clinical_index, sv_annotated_ranked_filtered | True        | vcf-sv-clinical-index               | scout, clinical-delivery, long-term-storage |
-| svs_per_caller, vcf_hificnv                         | True        | hificnv, vcf                        | long-term-storage                           |
-| svs_per_caller, vcf_hificnv_index                   | True        | hificnv, vcf-index                  | long-term-storage                           |
-| svs_per_caller, vcf_sawfish                         | True        | sawfish, vcf                        | long-term-storage                           |
-| svs_per_caller, vcf_sawfish_index                   | True        | sawfish, vcf-index                  | long-term-storage                           |
-| svs_per_caller, vcf_severus                         | True        | severus, vcf                        | long-term-storage                           |
-| svs_per_caller, vcf_severus_index                   | True        | severus, vcf-index                  | long-term-storage                           |
-| svs_per_caller, vcf_sniffles                        | True        | sniffles1, vcf                      | long-term-storage                           |
-| svs_per_caller, vcf_sniffles_index                  | True        | sniffles1, vcf-index                | long-term-storage                           |
-| copy_number, bedgraph                               | True        | cnv, bedgraph                       | clinical-delivery, long-term-storage        |
-| depth_track, bigwig                                 | True        | hificnv, bigwig                     | clinical-delivery, long-term-storage        |
-| maf_depth_track, bigwig                             | True        | hificnv, bigwig, maf                | clinical-delivery, long-term-storage        |
-| multiqc-json, multiqc                               | True        | multiqc-json                        | long-term-storage                           |
-| nextflow-params                                     | True        | nextflow-params                     | cg, long-term-storage                       |
-| nextflow-config                                     | True        | nextflow-config                     | cg, long-term-storage                       |
-| samplesheet                                         | True        | nextflow-samplesheet                | cg, long-term-storage                       |
-| software-versions                                   | True        | software-versions                   | cg, clinical-delivery, long-term-storage    |
-| qc-metrics                                          | True        | qc-metrics, deliverable             | cg, long-term-storage                       |
-| whatshap, gtf                                       | True        | bam, paraphase                      | scout, clinical-delivery, long-term-storage |
-| whatshap, gtf_index                                 | True        | bam, paraphase                      | scout, clinical-delivery, long-term-storage |
-| manifest                                            | False       | manifest                            | scout, long-term-storage                    |
-| chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                | scout                                          |
-| tcov, chromograph_cov                            | False       | chromograph, tcov                   | scout
+| methbat_hap1, methylation_pileup                    | True        | bed, hap1, methbat-pileup          | clinical-delivery, long-term-storage        |
+| methbat_hap1_index, methylation_pileup              | True        | bed-index, hap1, methbat-pileup    | clinical-delivery, long-term-storage        |
+| methbat_hap2, methylation_pileup                    | True        | bed, hap2, methbat-pileup          | clinical-delivery, long-term-storage        |
+| methbat_hap2_index, methylation_pileup              | True        | bed-index, hap2, methbat-pileup    | clinical-delivery, long-term-storage        |
+| methbat_combined, methylation_pileup                | True        | bed, combined, methbat-pileup      | clinical-delivery, long-term-storage        |
+| methbat_combined_index, methylation_pileup          | True        | bed-index, combined, modkit-pileup | clinical-delivery, long-term-storage        |
+| methbat_profile, methylation_calling                | True        | methylation-tsv, methbat-profile   | scout, clinical-delivery, long-term-storage |
+| mosdepth_d4, qc_bam                                 | False        | coverage, d4                       | scout, clinical-delivery, long-term-storage |
+| multiqc-html, multiqc                               | True        | multiqc-html                       | scout, clinical-delivery, long-term-storage |
+| pedigree_fam, pedigree                              | True        | pedigree                           | clinical-delivery, scout, long-term-storage |
+| relate_html, somalier                               | True        | somalier, relate-html              | clinical-delivery, scout, long-term-storage |
+| relate_pairs, somalier                              | True        | somalier, relate-pairs             | scout, long-term-storage                    |
+| relate_samples, somalier                            | True        | somalier, relate-samples           | scout, long-term-storage                    |
+| peddy                                               | True        | peddy, ped                         | audit, scout, clinical-delivery             |
+| ped_check, peddy                                    | True        | peddy, ped-check                   | audit, scout, clinical-delivery             |
+| peddy, sex_check                                    | True        | peddy, sex-check                   | audit, scout, clinical-delivery             |
+| deepvariant, report                                 | True        | deepvariant-report                 | clinical-delivery, long-term-storage        |
+| paraphase                                           | True        | cram, paraphase                    | clinical-delivery, long-term-storage        |
+| paraphase_index, paraphase                          | True        | cram-index, paraphase              | clinical-delivery, long-term-storage        |
+| json, paraphase                                     | True        | paraphase, json                    | clinical-delivery, long-term-storage        |
+| json, paraphrase                                    | False        | paraphrase, json                   | clinical-delivery, long-term-storage        |
+| tsv, paraphrase                                     | False        | paraphrase, tsv                    | clinical-delivery, long-term-storage        |
+| vcf, paraphase                                      | False       | paraphase, vcf                     | clinical-delivery, long-term-storage        |
+| vcf_index, paraphase                                | False       | paraphase, vcf-index               | clinical-delivery, long-term-storage        |
+| sambamba_depth                                      | True       | coverage, sambamba_depth           | cg, long-term-storage                          |
+| sorted_repeats, vcf_str                             | True        | repeats, sorted, vcf               | long-term-storage                           |
+| sorted_repeats, vcf_str_index                       | True        | repeats, sorted, vcf-index         | long-term-storage                           |
+| spanning_repeats, cram                              | True        | repeats, spanning, cram            | long-term-storage                           |
+| spanning_repeats, cram_index                        | True        | repeats, spanning, cram-index      | long-term-storage                           |
+| rank-model-snv                                      | True        | rank-model-snv                     | scout, long-term-storage                    |
+| repeats_annotated, vcf_str                          | True        | vcf-str                            | scout, clinical-delivery, long-term-storage |
+| repeats_annotated, vcf_str                          | True        | vcf-str                            | scout, clinical-delivery, long-term-storage |
+| repeats_annotated, vcf_str_index                    | True        | vcf-str-index                      | scout, clinical-delivery, long-term-storage |
+| trgt, variant_catalog                               | True        | trgt, variant-catalog              | scout, long-term-storage                    |
+| vcf_snv_research, snv_annotated                     | True        | vcf-snv-research                   | scout, clinical-delivery, long-term-storage |
+| vcf_snv_research_index, snv_annotated               | True        | vcf-snv-research-index             | scout, clinical-delivery, long-term-storage |
+| vcf_snv_clinical, snv_annotated_filtered            | True        | vcf-snv-clinical                   | scout, clinical-delivery, long-term-storage |
+| vcf_snv_clinical_index, snv_annotated_filtered      | True        | vcf-snv-clinical-index             | scout, clinical-delivery, long-term-storage |
+| vcf_sv_research, sv_annotated_ranked                | True        | vcf-sv-research                    | scout, clinical-delivery, long-term-storage |
+| vcf_sv_research_index, sv_annotated_ranked          | True        | vcf-sv-research-index              | scout, clinical-delivery, long-term-storage |
+| vcf_sv_clinical, sv_annotated_ranked_filtered       | True        | vcf-sv-clinical                    | scout, clinical-delivery, long-term-storage |
+| vcf_sv_clinical_index, sv_annotated_ranked_filtered | True        | vcf-sv-clinical-index              | scout, clinical-delivery, long-term-storage |
+| svs_per_caller, vcf_hificnv                         | True        | hificnv, vcf                       | long-term-storage                           |
+| svs_per_caller, vcf_hificnv_index                   | True        | hificnv, vcf-index                 | long-term-storage                           |
+| svs_per_caller, vcf_sawfish                         | True        | sawfish, vcf                       | long-term-storage                           |
+| svs_per_caller, vcf_sawfish_index                   | True        | sawfish, vcf-index                 | long-term-storage                           |
+| svs_per_caller, vcf_severus                         | True        | severus, vcf                       | long-term-storage                           |
+| svs_per_caller, vcf_severus_index                   | True        | severus, vcf-index                 | long-term-storage                           |
+| svs_per_caller, vcf_sniffles                        | True        | sniffles1, vcf                     | long-term-storage                           |
+| svs_per_caller, vcf_sniffles_index                  | True        | sniffles1, vcf-index               | long-term-storage                           |
+| copy_number, bedgraph                               | True        | cnv, bedgraph                      | clinical-delivery, long-term-storage        |
+| depth_track, bigwig                                 | True        | hificnv, bigwig                    | clinical-delivery, long-term-storage        |
+| maf_depth_track, bigwig                             | True        | hificnv, bigwig, maf               | clinical-delivery, long-term-storage        |
+| multiqc-json, multiqc                               | True        | multiqc-json                       | long-term-storage                           |
+| nextflow-params                                     | True        | nextflow-params                    | cg, long-term-storage                       |
+| nextflow-config                                     | True        | nextflow-config                    | cg, long-term-storage                       |
+| samplesheet                                         | True        | nextflow-samplesheet               | cg, long-term-storage                       |
+| software-versions                                   | True        | software-versions                  | cg, clinical-delivery, long-term-storage    |
+| qc-metrics                                          | True        | qc-metrics, deliverable            | cg, long-term-storage                       |
+| whatshap, gtf                                       | True        | bam, paraphase                     | scout, clinical-delivery, long-term-storage |
+| whatshap, gtf_index                                 | True        | bam, paraphase                     | scout, clinical-delivery, long-term-storage |
+| manifest                                            | False       | manifest                           | scout, long-term-storage                    |
+| chromograph_rhoviz, autozyg                         | False       | chromograph, autozyg               | scout                                          |
+| tcov, chromograph_cov                               | False       | chromograph, tcov                  | scout

--- a/docs/raredisease_map.md
+++ b/docs/raredisease_map.md
@@ -52,6 +52,8 @@
 | ped_check, peddy                                 | True        | peddy, ped-check                       | audit, scout, clinical-delivery                |
 | sex_check, peddy                                 | True        | peddy, sex-check                       | audit, scout, clinical-delivery                |
 | pedigree_fam, pedigree                           | True        | pedigree                               | scout                                          |
+| rank_model_snv, rank_and_filter                 | False       | rank-model-snv                         | scout                                          |
+| rank_model_sv, rank_and_filter                  | False       | rank-model-sv                          | scout                                          |
 | rhocallviz, annotate_snv                         | False       | rhocall-viz                            | scout                                          |
 | annotate_snv_mt, haplogrep                       | False       | haplogrep                              | scout, clinical-delivery                       |
 | chromograph_rhoviz, autozyg                      | False       | chromograph, autozyg                   | scout                                          |

--- a/tests/fixtures/nallo/case_id_deliverables.yaml
+++ b/tests/fixtures/nallo/case_id_deliverables.yaml
@@ -632,11 +632,11 @@ files:
   tag: qc-metrics
 - format: ini
   id: CASEID
-  path: PATHTOCASE/CASEID_rank_model_snvs.ini
+  path: PATHTOCASE/grch38_rank_model_snvs_-v1.0-.ini
   step: rank-model-snv
   tag: rank-model-snv
 - format: ini
   id: CASEID
-  path: PATHTOCASE/CASEID_rank_model_svs.ini
+  path: PATHTOCASE/grch38_rank_model_svs_-v1.0-.ini
   step: rank-model-sv
   tag: rank-model-sv

--- a/tests/fixtures/nallo/case_id_deliverables.yaml
+++ b/tests/fixtures/nallo/case_id_deliverables.yaml
@@ -633,10 +633,10 @@ files:
 - format: ini
   id: CASEID
   path: PATHTOCASE/CASEID_rank_model_snvs.ini
-  step: rank-models-snv
-  tag: rank-models-snv
+  step: rank-model-snv
+  tag: rank-model-snv
 - format: ini
   id: CASEID
   path: PATHTOCASE/CASEID_rank_model_svs.ini
-  step: rank-models-sv
-  tag: rank-models-sv
+  step: rank-model-sv
+  tag: rank-model-sv

--- a/tests/fixtures/nallo/case_id_deliverables.yaml
+++ b/tests/fixtures/nallo/case_id_deliverables.yaml
@@ -630,3 +630,13 @@ files:
   path: PATHTOCASE/CASEID_metrics_deliverables.yaml
   step: qc-metrics
   tag: qc-metrics
+- format: ini
+  id: CASEID
+  path: PATHTOCASE/CASEID_rank_model_snvs.ini
+  step: rank-models-snv
+  tag: rank-models-snv
+- format: ini
+  id: CASEID
+  path: PATHTOCASE/CASEID_rank_model_svs.ini
+  step: rank-models-sv
+  tag: rank-models-sv

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -830,3 +830,13 @@ files:
   path: PATHTOCASE/manifest.json
   step: manifest
   tag: manifest
+- format: ini
+  id: CASEID
+  path: PATHTOCASE/CASEID_rank_model_snvs.ini
+  step: rank-models-snv
+  tag: rank-models-snv
+- format: ini
+  id: CASEID
+  path: PATHTOCASE/CASEID_rank_model_svs.ini
+  step: rank-models-sv
+  tag: rank-models-sv

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -833,10 +833,10 @@ files:
 - format: ini
   id: CASEID
   path: PATHTOCASE/CASEID_rank_model_snvs.ini
-  step: rank-models-snv
-  tag: rank-models-snv
+  step: rank-model-snv
+  tag: rank-model-snv
 - format: ini
   id: CASEID
   path: PATHTOCASE/CASEID_rank_model_svs.ini
-  step: rank-models-sv
-  tag: rank-models-sv
+  step: rank-model-sv
+  tag: rank-model-sv

--- a/tests/fixtures/raredisease/case_id_deliverables.yaml
+++ b/tests/fixtures/raredisease/case_id_deliverables.yaml
@@ -832,11 +832,11 @@ files:
   tag: manifest
 - format: ini
   id: CASEID
-  path: PATHTOCASE/CASEID_rank_model_snvs.ini
+  path: PATHTOCASE/grch38_rank_model_-v0.4-.ini
   step: rank-model-snv
   tag: rank-model-snv
 - format: ini
   id: CASEID
-  path: PATHTOCASE/CASEID_rank_model_svs.ini
+  path: PATHTOCASE/grch38_sv_rank_model_-v0.2-.ini
   step: rank-model-sv
   tag: rank-model-sv


### PR DESCRIPTION
## Description
Add support for rank-model files to be added to the case housekeeper bundles in cg

### Added

- New set of tags `InputFileTags` with "rank-model-snv" and "rank-model-sv"
- Entries in the Tag dictionaries for Nallo and raredisease of SNV and SV rank model files

### Changed

- Updated docs

### Fixed

- Contributing page

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
hermes-test-deploy add-rank-model-files
hermes-test <command here>
```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test result
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
